### PR TITLE
Add testing addon support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
-# Go test
+# Run go test
 
 [![Step changelog](https://shields.io/github/v/release/bitrise-steplib/steps-go-test?include_prereleases&label=changelog&color=blueviolet)](https://github.com/bitrise-steplib/steps-go-test/releases)
 
-Runs Go test
+Runs go test command and exports the test results.
 
 <details>
 <summary>Description</summary>
 
-Runs Go test on the given packages one-by-one:
+Runs go test command and exports the test results.
 
 `go test -v <package>`
 </details>
@@ -25,7 +25,10 @@ You can also run this step directly with [Bitrise CLI](https://github.com/bitris
 
 | Key | Description | Flags | Default |
 | --- | --- | --- | --- |
-| `packages` | Newline separated list of Go packages, to run the Go test command against.  __Example:__  ``` github.com/my/step github.com/bitrise/step/tool ``` | required | `$BITRISE_GO_PACKAGES` |
+| `package` | The package argument to be passed to the go test command.  For example 'go test math', 'go test ./...', and even 'go test .' | required |  |
+| `covermode` | Set the mode for coverage analysis for the package[s] being tested.  Possible values are: - 'none': no coverage analysis - 'set': bool: does this statement run? - 'count': int: how many times does this statement run? - 'atomic': int: count, but correct in multithreaded tests; significantly more expensive. | required | `none` |
+| `test_options` | Additional options to be added to the executed go test command. |  |  |
+| `test_report_name` | Name of the generated test report JUnit xml to be used in Bitrise Test Reports.  If not specified the the provided package name will be used. |  |  |
 | `output_dir` | This directory will contain the generated artifacts. | required | `$BITRISE_DEPLOY_DIR` |
 </details>
 
@@ -34,7 +37,8 @@ You can also run this step directly with [Bitrise CLI](https://github.com/bitris
 
 | Environment Variable | Description |
 | --- | --- |
-| `GO_CODE_COVERAGE_REPORT_PATH` | Path to the code coverage report file, which contains each package's code coverage report. |
+| `GO_TEST_RUN_LOG_PATH` | Path to the generated test run log file. |
+| `GO_CODE_COVERAGE_REPORT_PATH` | Path to the generated code coverage profile file.  This output will be available only if the covermode is not 'none'. |
 </details>
 
 ## 🙋 Contributing

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Runs go test command and exports the test results.
 
 ## 🧩 Get started
 
-Add this step directly to your workflow in the [Bitrise Workflow Editor](https://devcenter.bitrise.io/steps-and-workflows/steps-and-workflows-index/).
+Add this step directly to your workflow in the [Bitrise Workflow Editor](https://docs.bitrise.io/en/bitrise-ci/workflows-and-pipelines/steps/adding-steps-to-a-workflow.html).
 
 You can also run this step directly with [Bitrise CLI](https://github.com/bitrise-io/bitrise).
 
@@ -45,9 +45,8 @@ You can also run this step directly with [Bitrise CLI](https://github.com/bitris
 
 We welcome [pull requests](https://github.com/bitrise-steplib/steps-go-test/pulls) and [issues](https://github.com/bitrise-steplib/steps-go-test/issues) against this repository.
 
-For pull requests, work on your changes in a forked repository and use the Bitrise CLI to [run step tests locally](https://devcenter.bitrise.io/bitrise-cli/run-your-first-build/).
+For pull requests, work on your changes in a forked repository and use the Bitrise CLI to [run step tests locally](https://docs.bitrise.io/en/bitrise-ci/bitrise-cli/running-your-first-local-build-with-the-cli.html).
 
 Learn more about developing steps:
 
-- [Create your own step](https://devcenter.bitrise.io/contributors/create-your-own-step/)
-- [Testing your Step](https://devcenter.bitrise.io/contributors/testing-and-versioning-your-steps/)
+- [Create your own step](https://docs.bitrise.io/en/bitrise-ci/workflows-and-pipelines/developing-your-own-bitrise-step/developing-a-new-step.html)

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ You can also run this step directly with [Bitrise CLI](https://github.com/bitris
 | `package` | The package argument to be passed to the go test command.  For example 'go test math', 'go test ./...', and even 'go test .' | required |  |
 | `covermode` | Set the mode for coverage analysis for the package[s] being tested.  Possible values are: - 'none': no coverage analysis - 'set': bool: does this statement run? - 'count': int: how many times does this statement run? - 'atomic': int: count, but correct in multithreaded tests; significantly more expensive. | required | `none` |
 | `test_options` | Additional options to be added to the executed go test command. |  |  |
-| `test_report_name` | Name of the generated test report JUnit xml to be used in Bitrise Test Reports.  If not specified the the provided package name will be used. |  |  |
+| `test_report_name` | Name of the generated test report JUnit xml to be used in Bitrise Test Reports.  If not specified the provided package name will be used. |  |  |
 | `output_dir` | This directory will contain the generated artifacts. | required | `$BITRISE_DEPLOY_DIR` |
 </details>
 

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -17,6 +17,7 @@ workflows:
     - path::./:
         inputs:
         - package: ./...
+        - covermode: set
         - test_report_name: All tests
 
   generate_readme:

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -17,6 +17,7 @@ workflows:
     - path::./:
         inputs:
         - packages: ./...
+        - test_report_name: All tests
 
   generate_readme:
     steps:

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -16,7 +16,7 @@ workflows:
     steps:
     - path::./:
         inputs:
-        - packages: ./...
+        - package: ./...
         - test_report_name: All tests
 
   generate_readme:

--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -8,6 +8,7 @@ workflows:
         title: Step Test
         inputs:
         - packages: ./...
+        - test_report_name: All tests
     - git::https://github.com/bitrise-steplib/bitrise-step-check-step-outputs.git@main:
         is_always_run: true
         inputs:

--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -8,6 +8,7 @@ workflows:
         title: Step Test
         inputs:
         - package: ./...
+        - covermode: set
         - test_report_name: All tests
     - git::https://github.com/bitrise-steplib/bitrise-step-check-step-outputs.git@main:
         is_always_run: true

--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -7,7 +7,7 @@ workflows:
     - path::./:
         title: Step Test
         inputs:
-        - packages: ./...
+        - package: ./...
         - test_report_name: All tests
     - git::https://github.com/bitrise-steplib/bitrise-step-check-step-outputs.git@main:
         is_always_run: true

--- a/filemanager/filemanager.go
+++ b/filemanager/filemanager.go
@@ -6,6 +6,8 @@ import (
 	"github.com/bitrise-io/go-utils/v2/fileutil"
 )
 
+// TODO: Check what functions are used
+
 // FileManager ...
 // TODO: fileutil.FileManager interface should be extended with more methods
 type FileManager interface {

--- a/filemanager/filemanager.go
+++ b/filemanager/filemanager.go
@@ -1,0 +1,46 @@
+package filemanager
+
+import (
+	"io"
+	"os"
+
+	"github.com/bitrise-io/go-utils/v2/fileutil"
+)
+
+// FileManager ...
+// TODO: fileutil.FileManager interface should be extended with more methods
+type FileManager interface {
+	Create(name string) (*os.File, error)
+	MkdirAll(path string, perm os.FileMode) error
+	Open(path string) (io.Reader, error)
+	Write(path string, value string, perm os.FileMode) error
+	RemoveAll(path string) error
+}
+
+type fileManager struct {
+	fileManager fileutil.FileManager
+}
+
+func New(manager fileutil.FileManager) FileManager {
+	return fileManager{fileManager: manager}
+}
+
+func (f fileManager) Create(name string) (*os.File, error) {
+	return os.Create(name)
+}
+
+func (f fileManager) MkdirAll(path string, perm os.FileMode) error {
+	return os.MkdirAll(path, perm)
+}
+
+func (f fileManager) Open(path string) (io.Reader, error) {
+	return f.fileManager.Open(path)
+}
+
+func (f fileManager) Write(path string, value string, perm os.FileMode) error {
+	return f.fileManager.Write(path, value, perm)
+}
+
+func (f fileManager) RemoveAll(path string) error {
+	return f.fileManager.RemoveAll(path)
+}

--- a/filemanager/filemanager.go
+++ b/filemanager/filemanager.go
@@ -1,7 +1,6 @@
 package filemanager
 
 import (
-	"io"
 	"os"
 
 	"github.com/bitrise-io/go-utils/v2/fileutil"
@@ -12,7 +11,7 @@ import (
 type FileManager interface {
 	Create(name string) (*os.File, error)
 	MkdirAll(path string, perm os.FileMode) error
-	Open(path string) (io.Reader, error)
+	Open(path string) (*os.File, error)
 	Write(path string, value string, perm os.FileMode) error
 	RemoveAll(path string) error
 }
@@ -33,7 +32,7 @@ func (f fileManager) MkdirAll(path string, perm os.FileMode) error {
 	return os.MkdirAll(path, perm)
 }
 
-func (f fileManager) Open(path string) (io.Reader, error) {
+func (f fileManager) Open(path string) (*os.File, error) {
 	return f.fileManager.Open(path)
 }
 

--- a/filemanager/filemanager.go
+++ b/filemanager/filemanager.go
@@ -15,7 +15,6 @@ type FileManager interface {
 	MkdirAll(path string, perm os.FileMode) error
 	Open(path string) (*os.File, error)
 	Write(path string, value string, perm os.FileMode) error
-	RemoveAll(path string) error
 }
 
 type fileManager struct {
@@ -40,8 +39,4 @@ func (f fileManager) Open(path string) (*os.File, error) {
 
 func (f fileManager) Write(path string, value string, perm os.FileMode) error {
 	return f.fileManager.Write(path, value, perm)
-}
-
-func (f fileManager) RemoveAll(path string) error {
-	return f.fileManager.RemoveAll(path)
 }

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/bitrise-io/go-steputils/v2 v2.0.0-alpha.37
 	github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.23
 	github.com/jstemmer/go-junit-report/v2 v2.1.0
+	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
 	github.com/stretchr/testify v1.10.0
 )
 

--- a/go.mod
+++ b/go.mod
@@ -5,12 +5,14 @@ go 1.21
 require (
 	github.com/bitrise-io/go-steputils/v2 v2.0.0-alpha.37
 	github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.23
+	github.com/jstemmer/go-junit-report/v2 v2.1.0
 	github.com/stretchr/testify v1.10.0
 )
 
 require (
 	github.com/bitrise-io/go-utils v1.0.14 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/google/go-cmp v0.6.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/stretchr/objx v0.5.2 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -16,6 +16,8 @@ github.com/hashicorp/go-hclog v0.9.2/go.mod h1:5CU+agLiy3J7N7QjHK5d05KxGsuXiQLrj
 github.com/hashicorp/go-retryablehttp v0.7.0/go.mod h1:vAew36LZh98gCBJNLH42IQ1ER/9wtLZZ8meHqQvEYWY=
 github.com/jstemmer/go-junit-report/v2 v2.1.0 h1:X3+hPYlSczH9IMIpSC9CQSZA0L+BipYafciZUWHEmsc=
 github.com/jstemmer/go-junit-report/v2 v2.1.0/go.mod h1:mgHVr7VUo5Tn8OLVr1cKnLuEy0M92wdRntM99h7RkgQ=
+github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 h1:Z9n2FFNUXsshfwJMBgNA0RU6/i7WVaAegv3PtuIHPMs=
+github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51/go.mod h1:CzGEWj7cYgsdH8dAjBGEr58BoE7ScuLd+fwFZ44+/x8=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/go.sum
+++ b/go.sum
@@ -7,10 +7,15 @@ github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.23/go.mod h1:3XUplo0dOWc3DqT2XA2S
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/google/go-cmp v0.5.8/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
+github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/hashicorp/go-cleanhttp v0.5.1/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
 github.com/hashicorp/go-cleanhttp v0.5.2/go.mod h1:kO/YDlP8L1346E6Sodw+PrpBSV4/SoxCXGY6BqNFT48=
 github.com/hashicorp/go-hclog v0.9.2/go.mod h1:5CU+agLiy3J7N7QjHK5d05KxGsuXiQLrjA0H7acj2lQ=
 github.com/hashicorp/go-retryablehttp v0.7.0/go.mod h1:vAew36LZh98gCBJNLH42IQ1ER/9wtLZZ8meHqQvEYWY=
+github.com/jstemmer/go-junit-report/v2 v2.1.0 h1:X3+hPYlSczH9IMIpSC9CQSZA0L+BipYafciZUWHEmsc=
+github.com/jstemmer/go-junit-report/v2 v2.1.0/go.mod h1:mgHVr7VUo5Tn8OLVr1cKnLuEy0M92wdRntM99h7RkgQ=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/main.go
+++ b/main.go
@@ -32,7 +32,7 @@ func run() exitcode.ExitCode {
 		return exitcode.Failure
 	}
 
-	runOpts := step.RunOpts{Packages: config.Packages, OutputDir: config.OutputDir}
+	runOpts := step.RunOpts{Packages: config.Packages, TestOptions: config.TestOptions, OutputDir: config.OutputDir}
 	runResult, err := goTestRunner.Run(runOpts)
 	if err != nil {
 		logger.Errorf(errorutil.FormattedError(fmt.Errorf("Failed to execute Step: %w", err)))

--- a/main.go
+++ b/main.go
@@ -32,16 +32,27 @@ func run() exitcode.ExitCode {
 		return exitcode.Failure
 	}
 
-	runOpts := step.RunOpts{Packages: config.Packages, TestOptions: config.TestOptions, OutputDir: config.OutputDir}
-	runResult, err := goTestRunner.Run(runOpts)
-	if err != nil {
-		logger.Errorf(errorutil.FormattedError(fmt.Errorf("Failed to execute Step: %w", err)))
+	runOpts := step.RunOpts{Package: config.Package, TestOptions: config.TestOptions, OutputDir: config.OutputDir}
+	runResult, runErr := goTestRunner.Run(runOpts)
+
+	testReportName := config.TestReportName
+	if testReportName == "" {
+		testReportName = config.Package
+	}
+	exportOpts := step.ExportOpts{TestRunLogPth: runResult.TestRunLogPath, CodeCoveragePth: runResult.CodeCoveragePth, TestReportName: testReportName}
+	exportErr := goTestRunner.ExportOutput(exportOpts)
+
+	if runErr != nil && exportErr != nil {
+		logger.Warnf(errorutil.FormattedError(fmt.Errorf("Failed to export Step outputs: %w", exportErr)))
+		logger.Errorf(errorutil.FormattedError(fmt.Errorf("Failed to run the tests: %w", runErr)))
 		return exitcode.Failure
 	}
-
-	exportOpts := step.ExportOpts{CodeCoveragePth: runResult.CodeCoveragePth, TestRunLogFilePaths: runResult.TestRunLogFilePaths, PackagesToTestReportNames: config.PackagesToTestReportNames}
-	if err := goTestRunner.ExportOutput(exportOpts); err != nil {
-		logger.Errorf(errorutil.FormattedError(fmt.Errorf("Failed to export Step outputs: %w", err)))
+	if runErr != nil {
+		logger.Errorf(errorutil.FormattedError(fmt.Errorf("Failed to run the tests: %w", runErr)))
+		return exitcode.Failure
+	}
+	if exportErr != nil {
+		logger.Errorf(errorutil.FormattedError(fmt.Errorf("Failed to export Step outputs: %w", exportErr)))
 		return exitcode.Failure
 	}
 
@@ -55,7 +66,7 @@ func createGoTestRunner(logger log.Logger) step.GoTestRunner {
 	exporter := export.NewExporter(cmdFactory)
 	pathProvider := pathutil.NewPathProvider()
 	fileManager := filemanager.New(fileutil.NewFileManager())
-	testaddonExporter := testaddon.NewExporter(envRepo, fileManager)
+	testAddonExporter := testaddon.NewExporter(envRepo, fileManager)
 
-	return step.NewGoTestRunner(logger, inputParser, envRepo, cmdFactory, &exporter, pathProvider, fileManager, testaddonExporter)
+	return step.NewGoTestRunner(logger, inputParser, envRepo, cmdFactory, &exporter, pathProvider, fileManager, testAddonExporter)
 }

--- a/main.go
+++ b/main.go
@@ -32,23 +32,36 @@ func run() exitcode.ExitCode {
 		return exitcode.Failure
 	}
 
-	runOpts := step.RunOpts{Package: config.Package, TestOptions: config.TestOptions, OutputDir: config.OutputDir}
+	runOpts := step.RunOpts{
+		Package:     config.Package,
+		Covermode:   config.Covermode,
+		TestOptions: config.TestOptions,
+		OutputDir:   config.OutputDir,
+	}
 	runResult, runErr := goTestRunner.Run(runOpts)
+	if runResult == nil {
+		logger.Errorf(errorutil.FormattedError(fmt.Errorf("Failed to execute Step main logic: %w", runErr)))
+		return exitcode.Failure
+	}
 
 	testReportName := config.TestReportName
 	if testReportName == "" {
 		testReportName = config.Package
 	}
-	exportOpts := step.ExportOpts{TestRunLogPth: runResult.TestRunLogPath, CodeCoveragePth: runResult.CodeCoveragePth, TestReportName: testReportName}
+	exportOpts := step.ExportOpts{
+		TestRunLogPth:   runResult.TestRunLogPath,
+		CodeCoveragePth: runResult.CodeCoveragePth,
+		TestReportName:  testReportName,
+	}
 	exportErr := goTestRunner.ExportOutput(exportOpts)
 
 	if runErr != nil && exportErr != nil {
 		logger.Warnf(errorutil.FormattedError(fmt.Errorf("Failed to export Step outputs: %w", exportErr)))
-		logger.Errorf(errorutil.FormattedError(fmt.Errorf("Failed to run the tests: %w", runErr)))
+		logger.Errorf(errorutil.FormattedError(fmt.Errorf("Failed to execute Step main logic: %w", runErr)))
 		return exitcode.Failure
 	}
 	if runErr != nil {
-		logger.Errorf(errorutil.FormattedError(fmt.Errorf("Failed to run the tests: %w", runErr)))
+		logger.Errorf(errorutil.FormattedError(fmt.Errorf("Failed to execute Step main logic: %w", runErr)))
 		return exitcode.Failure
 	}
 	if exportErr != nil {

--- a/main.go
+++ b/main.go
@@ -32,14 +32,14 @@ func run() exitcode.ExitCode {
 		return exitcode.Failure
 	}
 
-	runOpts := step.RunOpts(config)
+	runOpts := step.RunOpts{Packages: config.Packages, OutputDir: config.OutputDir}
 	runResult, err := goTestRunner.Run(runOpts)
 	if err != nil {
 		logger.Errorf(errorutil.FormattedError(fmt.Errorf("Failed to execute Step: %w", err)))
 		return exitcode.Failure
 	}
 
-	exportOpts := step.ExportOpts{CodeCoveragePth: runResult.CodeCoveragePth, TestRunLogFilePaths: runResult.TestRunLogFilePaths}
+	exportOpts := step.ExportOpts{CodeCoveragePth: runResult.CodeCoveragePth, TestRunLogFilePaths: runResult.TestRunLogFilePaths, PackagesToTestReportNames: config.PackagesToTestReportNames}
 	if err := goTestRunner.ExportOutput(exportOpts); err != nil {
 		logger.Errorf(errorutil.FormattedError(fmt.Errorf("Failed to export Step outputs: %w", err)))
 		return exitcode.Failure

--- a/main.go
+++ b/main.go
@@ -13,7 +13,9 @@ import (
 	"github.com/bitrise-io/go-utils/v2/fileutil"
 	"github.com/bitrise-io/go-utils/v2/log"
 	"github.com/bitrise-io/go-utils/v2/pathutil"
+	"github.com/bitrise-steplib/steps-go-test/filemanager"
 	"github.com/bitrise-steplib/steps-go-test/step"
+	"github.com/bitrise-steplib/steps-go-test/testaddon"
 )
 
 func main() {
@@ -37,7 +39,7 @@ func run() exitcode.ExitCode {
 		return exitcode.Failure
 	}
 
-	exportOpts := step.ExportOpts{CodeCoveragePth: runResult.CodeCoveragePth}
+	exportOpts := step.ExportOpts{CodeCoveragePth: runResult.CodeCoveragePth, TestRunLogFilePaths: runResult.TestRunLogFilePaths}
 	if err := goTestRunner.ExportOutput(exportOpts); err != nil {
 		logger.Errorf(errorutil.FormattedError(fmt.Errorf("Failed to export Step outputs: %w", err)))
 		return exitcode.Failure
@@ -52,7 +54,8 @@ func createGoTestRunner(logger log.Logger) step.GoTestRunner {
 	cmdFactory := command.NewFactory(envRepo)
 	exporter := export.NewExporter(cmdFactory)
 	pathProvider := pathutil.NewPathProvider()
-	fileManager := step.NewFileManager(fileutil.NewFileManager())
+	fileManager := filemanager.New(fileutil.NewFileManager())
+	testaddonExporter := testaddon.NewExporter(envRepo, fileManager)
 
-	return step.NewGoTestRunner(logger, inputParser, envRepo, cmdFactory, &exporter, pathProvider, fileManager)
+	return step.NewGoTestRunner(logger, inputParser, envRepo, cmdFactory, &exporter, pathProvider, fileManager, testaddonExporter)
 }

--- a/mocks/FileManager.go
+++ b/mocks/FileManager.go
@@ -3,9 +3,7 @@
 package mocks
 
 import (
-	io "io"
 	fs "io/fs"
-
 	os "os"
 
 	mock "github.com/stretchr/testify/mock"
@@ -57,19 +55,19 @@ func (_m *FileManager) MkdirAll(path string, perm fs.FileMode) error {
 }
 
 // Open provides a mock function with given fields: path
-func (_m *FileManager) Open(path string) (io.Reader, error) {
+func (_m *FileManager) Open(path string) (*os.File, error) {
 	ret := _m.Called(path)
 
-	var r0 io.Reader
+	var r0 *os.File
 	var r1 error
-	if rf, ok := ret.Get(0).(func(string) (io.Reader, error)); ok {
+	if rf, ok := ret.Get(0).(func(string) (*os.File, error)); ok {
 		return rf(path)
 	}
-	if rf, ok := ret.Get(0).(func(string) io.Reader); ok {
+	if rf, ok := ret.Get(0).(func(string) *os.File); ok {
 		r0 = rf(path)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(io.Reader)
+			r0 = ret.Get(0).(*os.File)
 		}
 	}
 

--- a/step.yml
+++ b/step.yml
@@ -63,7 +63,7 @@ inputs:
     description: |-
       Name of the generated test report JUnit xml to be used in Bitrise Test Reports.
 
-      If not specified the the provided package name will be used.
+      If not specified the provided package name will be used.
 
 - output_dir: $BITRISE_DEPLOY_DIR
   opts:

--- a/step.yml
+++ b/step.yml
@@ -1,7 +1,7 @@
-title: Go test
-summary: Runs Go test
+title: Run go test
+summary: Runs go test command and exports the test results.
 description: |-
-  Runs Go test on the given packages one-by-one:
+  Runs go test command and exports the test results.
 
   `go test -v <package>`
 
@@ -21,12 +21,34 @@ toolkit:
   go:
     package_name: github.com/bitrise-steplib/steps-go-test
 
-# TODO: update inputs
 inputs:
-- package: $BITRISE_GO_PACKAGES
+- package:
   opts:
-    title: Go test target package
-    summary: Go package to test.
+    title: Go package[s] being tested.
+    summary: The package argument to be passed to the go test command.
+    description: |-
+      The package argument to be passed to the go test command.
+
+      For example 'go test math', 'go test ./...', and even 'go test .'
+    is_required: true
+
+- covermode: none
+  opts:
+    title: coverage analysis mode
+    summary: Set the mode for coverage analysis for the package[s] being tested.
+    description: |-
+      Set the mode for coverage analysis for the package[s] being tested.
+
+      Possible values are:
+      - 'none': no coverage analysis
+      - 'set': bool: does this statement run?
+      - 'count': int: how many times does this statement run?
+      - 'atomic': int: count, but correct in multithreaded tests; significantly more expensive.
+    value_options:
+    - none
+    - set
+    - count
+    - atomic
     is_required: true
 
 - test_options:
@@ -37,7 +59,11 @@ inputs:
 - test_report_name:
   opts:
     title: Name of the test report
-    summary: Name of the test report to be used in Bitrise Test Reports.
+    summary: Name of the generated test report JUnit xml to be used in Bitrise Test Reports.
+    description: |-
+      Name of the generated test report JUnit xml to be used in Bitrise Test Reports.
+
+      If not specified the the provided package name will be used.
 
 - output_dir: $BITRISE_DEPLOY_DIR
   opts:
@@ -46,8 +72,16 @@ inputs:
     is_required: true
 
 outputs:
+- GO_TEST_RUN_LOG_PATH:
+  opts:
+    title: Test run log file path
+    summary: Path to the generated test run log file.
+
 - GO_CODE_COVERAGE_REPORT_PATH:
   opts:
-    title: Code coverage report file path
-    summary: Path to the code coverage report file.
-    description: Path to the code coverage report file, which contains each package's code coverage report.
+    title: Code coverage profile file path
+    summary: Path to the generated code coverage profile file.
+    description: |-
+      Path to the generated code coverage profile file.
+
+      This output will be available only if the covermode is not 'none'.

--- a/step.yml
+++ b/step.yml
@@ -43,6 +43,11 @@ inputs:
     summary: This directory will contain the generated artifacts.
     is_required: true
 
+- test_report_name:
+  opts:
+    title: Name of the test report
+    summary: Name of the test report to be used in Bitrise Test Reports
+
 outputs:
 - GO_CODE_COVERAGE_REPORT_PATH:
   opts:

--- a/step.yml
+++ b/step.yml
@@ -21,20 +21,12 @@ toolkit:
   go:
     package_name: github.com/bitrise-steplib/steps-go-test
 
+# TODO: update inputs
 inputs:
-- packages: $BITRISE_GO_PACKAGES
+- package: $BITRISE_GO_PACKAGES
   opts:
-    title: Go test target packages
-    summary: List of Go packages to test.
-    description: |-
-      Newline separated list of Go packages, to run the Go test command against.
-
-      __Example:__
-
-      ```
-      github.com/my/step
-      github.com/bitrise/step/tool
-      ```
+    title: Go test target package
+    summary: Go package to test.
     is_required: true
 
 - test_options:

--- a/step.yml
+++ b/step.yml
@@ -37,16 +37,21 @@ inputs:
       ```
     is_required: true
 
+- test_options:
+  opts:
+    title: Additional options for the go test command
+    summary: Additional options to be added to the executed go test command.
+
+- test_report_name:
+  opts:
+    title: Name of the test report
+    summary: Name of the test report to be used in Bitrise Test Reports.
+
 - output_dir: $BITRISE_DEPLOY_DIR
   opts:
     title: Output directory path
     summary: This directory will contain the generated artifacts.
     is_required: true
-
-- test_report_name:
-  opts:
-    title: Name of the test report
-    summary: Name of the test report to be used in Bitrise Test Reports
 
 outputs:
 - GO_CODE_COVERAGE_REPORT_PATH:

--- a/step/step.go
+++ b/step/step.go
@@ -21,7 +21,7 @@ import (
 
 type Inputs struct {
 	Package        string `env:"package,required"`
-	Covermode      string `env:"covermode,opt[none,set,atomic,count]"`
+	Covermode      string `env:"covermode,opt[none,set,count,atomic]"`
 	TestOptions    string `env:"test_options"`
 	TestReportName string `env:"test_report_name"`
 	OutputDir      string `env:"output_dir,required"`
@@ -159,7 +159,10 @@ func (s GoTestRunner) Run(opts RunOpts) (*RunResult, error) {
 		runResult.CodeCoveragePth = codeCoverageFile.Name()
 	}
 
-	return &runResult, cmd.Run()
+	if err := cmd.Run(); err != nil {
+		return &runResult, fmt.Errorf("go test failed: %w", err)
+	}
+	return &runResult, nil
 }
 
 type ExportOpts struct {

--- a/step/step.go
+++ b/step/step.go
@@ -109,7 +109,7 @@ func (s GoTestRunner) Run(opts RunOpts) (*RunResult, error) {
 
 	testRunLogFilePaths := map[string]string{}
 
-	for _, p := range opts.Packages {
+	for _, pkg := range opts.Packages {
 		logFile, err := s.testRunLogTmpFile()
 		if err != nil {
 			return nil, fmt.Errorf("failed to create tmp file for test run logs: %w", err)
@@ -118,7 +118,7 @@ func (s GoTestRunner) Run(opts RunOpts) (*RunResult, error) {
 		outWriter := io.MultiWriter(os.Stdout, logFile)
 		errWriter := io.MultiWriter(os.Stderr, logFile)
 
-		cmd := s.cmdFactory.Create("go", []string{"test", "-v", "-race", "-coverprofile=" + packageCodeCoveragePth, "-covermode=atomic", p}, &command.Opts{
+		cmd := s.cmdFactory.Create("go", []string{"test", "-v", "-race", "-coverprofile=" + packageCodeCoveragePth, "-covermode=atomic", pkg}, &command.Opts{
 			Stdout: outWriter,
 			Stderr: errWriter,
 		})
@@ -136,7 +136,7 @@ func (s GoTestRunner) Run(opts RunOpts) (*RunResult, error) {
 			return nil, fmt.Errorf("failed to append package coverage: %w", err)
 		}
 
-		testRunLogFilePaths[p] = logFile.Name()
+		testRunLogFilePaths[pkg] = logFile.Name()
 	}
 
 	return &RunResult{
@@ -157,13 +157,7 @@ func (s GoTestRunner) ExportOutput(opts ExportOpts) error {
 
 	s.logger.Donef("\ncode coverage is available at: GO_CODE_COVERAGE_REPORT_PATH=%s", opts.CodeCoveragePth)
 
-	idx := 0
 	for pkg, testRunLogFilePth := range opts.TestRunLogFilePaths {
-		idx++
-
-		testName := fmt.Sprintf("Test run #%d (%s)", idx, pkg)
-		testName = s.testaddonExporter.ReplaceUnsupportedFilenameCharacters(testName)
-
 		testRunLogFile, err := s.fileManager.Open(testRunLogFilePth)
 		if err != nil {
 			return fmt.Errorf("failed to open test run log file: %w", err)
@@ -177,7 +171,7 @@ func (s GoTestRunner) ExportOutput(opts ExportOpts) error {
 			return fmt.Errorf("failed to parse go test report: %w", parseErr)
 		}
 
-		reportFile, err := s.testaddonExporter.PrepareTestResultExport(testName)
+		reportFile, err := s.testaddonExporter.PrepareTestResultExport(pkg)
 		if err != nil {
 			return fmt.Errorf("failed to prepare test result export: %w", err)
 		}

--- a/step/step.go
+++ b/step/step.go
@@ -21,6 +21,7 @@ import (
 
 type Inputs struct {
 	Package        string `env:"package,required"`
+	Covermode      string `env:"covermode,opt[none,set,atomic,count]"`
 	TestOptions    string `env:"test_options"`
 	TestReportName string `env:"test_report_name"`
 	OutputDir      string `env:"output_dir,required"`
@@ -28,6 +29,7 @@ type Inputs struct {
 
 type Config struct {
 	Package        string
+	Covermode      string
 	TestOptions    []string
 	TestReportName string
 	OutputDir      string
@@ -81,9 +83,14 @@ func (s GoTestRunner) ProcessInputs() (*Config, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse test options: %w", err)
 	}
+	covermode := strings.TrimSpace(inputs.Covermode)
+	if covermode == "none" {
+		covermode = ""
+	}
 
 	return &Config{
 		Package:        pkg,
+		Covermode:      covermode,
 		TestOptions:    testOptions,
 		TestReportName: testReportName,
 		OutputDir:      inputs.OutputDir,
@@ -92,6 +99,7 @@ func (s GoTestRunner) ProcessInputs() (*Config, error) {
 
 type RunOpts struct {
 	Package     string
+	Covermode   string
 	TestOptions []string
 	OutputDir   string
 }
@@ -102,16 +110,6 @@ type RunResult struct {
 }
 
 func (s GoTestRunner) Run(opts RunOpts) (*RunResult, error) {
-	codeCoverageFile, err := s.createCodeCoverageFile(opts.OutputDir)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create package code coverage file: %w", err)
-	}
-	defer func() {
-		if err := codeCoverageFile.Close(); err != nil {
-			s.logger.Warnf("Failed to close code coverage file: %s", err)
-		}
-	}()
-
 	testRunLogFile, err := s.testRunLogFile(opts.OutputDir)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create tmp file for test run logs: %w", err)
@@ -122,10 +120,27 @@ func (s GoTestRunner) Run(opts RunOpts) (*RunResult, error) {
 		}
 	}()
 
+	var codeCoverageFile *os.File
+	if opts.Covermode != "" {
+		var err error
+		codeCoverageFile, err = s.createCodeCoverageFile(opts.OutputDir)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create package code coverage file: %w", err)
+		}
+		defer func() {
+			if err := codeCoverageFile.Close(); err != nil {
+				s.logger.Warnf("Failed to close code coverage file: %s", err)
+			}
+		}()
+	}
+
 	outWriter := io.MultiWriter(os.Stdout, testRunLogFile)
 	errWriter := io.MultiWriter(os.Stderr, testRunLogFile)
 
-	args := []string{"test", "-v", "-coverprofile=" + codeCoverageFile.Name(), "-covermode=atomic"}
+	args := []string{"test", "-v"}
+	if opts.Covermode != "" {
+		args = append(args, "-covermode="+opts.Covermode, "-coverprofile="+codeCoverageFile.Name())
+	}
 	if len(opts.TestOptions) > 0 {
 		args = append(args, opts.TestOptions...)
 	}
@@ -137,10 +152,14 @@ func (s GoTestRunner) Run(opts RunOpts) (*RunResult, error) {
 	})
 	s.logger.Printf("$ %s", cmd.PrintableCommandArgs())
 
-	return &RunResult{
-		CodeCoveragePth: codeCoverageFile.Name(),
-		TestRunLogPath:  testRunLogFile.Name(),
-	}, cmd.Run()
+	runResult := RunResult{
+		TestRunLogPath: testRunLogFile.Name(),
+	}
+	if opts.Covermode != "" {
+		runResult.CodeCoveragePth = codeCoverageFile.Name()
+	}
+
+	return &runResult, cmd.Run()
 }
 
 type ExportOpts struct {
@@ -155,10 +174,12 @@ func (s GoTestRunner) ExportOutput(opts ExportOpts) error {
 	}
 	s.logger.Donef("\ngo test run log file is available at: GO_TEST_RUN_LOG_PATH=%s", opts.TestRunLogPth)
 
-	if err := s.outputExporter.ExportOutput("GO_CODE_COVERAGE_REPORT_PATH", opts.CodeCoveragePth); err != nil {
-		return fmt.Errorf("failed to export GO_CODE_COVERAGE_REPORT_PATH=%s: %w", opts.CodeCoveragePth, err)
+	if opts.CodeCoveragePth != "" {
+		if err := s.outputExporter.ExportOutput("GO_CODE_COVERAGE_REPORT_PATH", opts.CodeCoveragePth); err != nil {
+			return fmt.Errorf("failed to export GO_CODE_COVERAGE_REPORT_PATH=%s: %w", opts.CodeCoveragePth, err)
+		}
+		s.logger.Donef("code coverage file is available at: GO_CODE_COVERAGE_REPORT_PATH=%s", opts.CodeCoveragePth)
 	}
-	s.logger.Donef("code coverage file is available at: GO_CODE_COVERAGE_REPORT_PATH=%s", opts.CodeCoveragePth)
 
 	testRunLogFile, err := s.fileManager.Open(opts.TestRunLogPth)
 	if err != nil {

--- a/step/step.go
+++ b/step/step.go
@@ -114,11 +114,6 @@ func (s GoTestRunner) Run(opts RunOpts) (*RunResult, error) {
 		if err != nil {
 			return nil, fmt.Errorf("failed to create tmp file for test run logs: %w", err)
 		}
-		defer func() {
-			if err := logFile.Close(); err != nil {
-				s.logger.Warnf("Failed to close test run log file: %s", err)
-			}
-		}()
 
 		outWriter := io.MultiWriter(os.Stdout, logFile)
 		errWriter := io.MultiWriter(os.Stderr, logFile)
@@ -128,8 +123,13 @@ func (s GoTestRunner) Run(opts RunOpts) (*RunResult, error) {
 			Stderr: errWriter,
 		})
 		s.logger.Printf("$ %s", cmd.PrintableCommandArgs())
-		if err := cmd.Run(); err != nil {
-			return nil, fmt.Errorf("go test failed: %w", err)
+
+		testRunErr := cmd.Run()
+		if err := logFile.Close(); err != nil {
+			s.logger.Warnf("Failed to close test run log file: %s", err)
+		}
+		if testRunErr != nil {
+			return nil, fmt.Errorf("go test failed: %w", testRunErr)
 		}
 
 		if err := s.appendPackageCoverageAndRecreate(packageCodeCoveragePth, codeCoveragePth); err != nil {
@@ -169,10 +169,14 @@ func (s GoTestRunner) ExportOutput(opts ExportOpts) error {
 			return fmt.Errorf("failed to open test run log file: %w", err)
 		}
 
-		report, err := gotest.NewParser().Parse(testRunLogFile)
-		if err != nil {
-			return fmt.Errorf("failed to parse go test report: %w", err)
+		report, parseErr := gotest.NewParser().Parse(testRunLogFile)
+		if err := testRunLogFile.Close(); err != nil {
+			s.logger.Warnf("Failed to close test run log file: %s", err)
 		}
+		if parseErr != nil {
+			return fmt.Errorf("failed to parse go test report: %w", parseErr)
+		}
+
 		reportFile, err := s.testaddonExporter.PrepareTestResultExport(testName)
 		if err != nil {
 			return fmt.Errorf("failed to prepare test result export: %w", err)
@@ -182,6 +186,7 @@ func (s GoTestRunner) ExportOutput(opts ExportOpts) error {
 		if err := testsuits.WriteXML(reportFile); err != nil {
 			return fmt.Errorf("failed to write test report: %w", err)
 		}
+
 		s.logger.Printf("\nTest report is available at: %s", reportFile.Name())
 	}
 

--- a/step/step.go
+++ b/step/step.go
@@ -13,6 +13,10 @@ import (
 	"github.com/bitrise-io/go-utils/v2/env"
 	"github.com/bitrise-io/go-utils/v2/log"
 	"github.com/bitrise-io/go-utils/v2/pathutil"
+	"github.com/bitrise-steplib/steps-go-test/filemanager"
+	"github.com/bitrise-steplib/steps-go-test/testaddon"
+	"github.com/jstemmer/go-junit-report/v2/junit"
+	"github.com/jstemmer/go-junit-report/v2/parser/gotest"
 )
 
 type Inputs struct {
@@ -26,13 +30,14 @@ type Config struct {
 }
 
 type GoTestRunner struct {
-	logger         log.Logger
-	inputParser    stepconf.InputParser
-	envRepo        env.Repository
-	cmdFactory     command.Factory
-	outputExporter OutputExporter
-	pathProvider   pathutil.PathProvider
-	fileManager    FileManager
+	logger            log.Logger
+	inputParser       stepconf.InputParser
+	envRepo           env.Repository
+	cmdFactory        command.Factory
+	outputExporter    OutputExporter
+	pathProvider      pathutil.PathProvider
+	fileManager       filemanager.FileManager
+	testaddonExporter testaddon.Exporter
 }
 
 func NewGoTestRunner(
@@ -42,16 +47,18 @@ func NewGoTestRunner(
 	cmdFactory command.Factory,
 	outputExporter OutputExporter,
 	pathProvider pathutil.PathProvider,
-	fileManager FileManager,
+	fileManager filemanager.FileManager,
+	testaddonExporter testaddon.Exporter,
 ) GoTestRunner {
 	return GoTestRunner{
-		logger:         logger,
-		inputParser:    inputParser,
-		envRepo:        envRepo,
-		cmdFactory:     cmdFactory,
-		outputExporter: outputExporter,
-		pathProvider:   pathProvider,
-		fileManager:    fileManager,
+		logger:            logger,
+		inputParser:       inputParser,
+		envRepo:           envRepo,
+		cmdFactory:        cmdFactory,
+		outputExporter:    outputExporter,
+		pathProvider:      pathProvider,
+		fileManager:       fileManager,
+		testaddonExporter: testaddonExporter,
 	}
 }
 
@@ -85,7 +92,8 @@ type RunOpts struct {
 }
 
 type RunResult struct {
-	CodeCoveragePth string
+	CodeCoveragePth     string
+	TestRunLogFilePaths map[string]string
 }
 
 func (s GoTestRunner) Run(opts RunOpts) (*RunResult, error) {
@@ -99,10 +107,25 @@ func (s GoTestRunner) Run(opts RunOpts) (*RunResult, error) {
 		return nil, fmt.Errorf("failed to get code coverage path: %w", err)
 	}
 
+	testRunLogFilePaths := map[string]string{}
+
 	for _, p := range opts.Packages {
+		logFile, err := s.testRunLogTmpFile()
+		if err != nil {
+			return nil, fmt.Errorf("failed to create tmp file for test run logs: %w", err)
+		}
+		defer func() {
+			if err := logFile.Close(); err != nil {
+				s.logger.Warnf("Failed to close test run log file: %s", err)
+			}
+		}()
+
+		outWriter := io.MultiWriter(os.Stdout, logFile)
+		errWriter := io.MultiWriter(os.Stderr, logFile)
+
 		cmd := s.cmdFactory.Create("go", []string{"test", "-v", "-race", "-coverprofile=" + packageCodeCoveragePth, "-covermode=atomic", p}, &command.Opts{
-			Stdout: os.Stdout,
-			Stderr: os.Stderr,
+			Stdout: outWriter,
+			Stderr: errWriter,
 		})
 		s.logger.Printf("$ %s", cmd.PrintableCommandArgs())
 		if err := cmd.Run(); err != nil {
@@ -112,15 +135,19 @@ func (s GoTestRunner) Run(opts RunOpts) (*RunResult, error) {
 		if err := s.appendPackageCoverageAndRecreate(packageCodeCoveragePth, codeCoveragePth); err != nil {
 			return nil, fmt.Errorf("failed to append package coverage: %w", err)
 		}
+
+		testRunLogFilePaths[p] = logFile.Name()
 	}
 
 	return &RunResult{
-		CodeCoveragePth: codeCoveragePth,
+		CodeCoveragePth:     codeCoveragePth,
+		TestRunLogFilePaths: testRunLogFilePaths,
 	}, nil
 }
 
 type ExportOpts struct {
-	CodeCoveragePth string
+	CodeCoveragePth     string
+	TestRunLogFilePaths map[string]string
 }
 
 func (s GoTestRunner) ExportOutput(opts ExportOpts) error {
@@ -129,7 +156,51 @@ func (s GoTestRunner) ExportOutput(opts ExportOpts) error {
 	}
 
 	s.logger.Donef("\ncode coverage is available at: GO_CODE_COVERAGE_REPORT_PATH=%s", opts.CodeCoveragePth)
+
+	idx := 0
+	for pkg, testRunLogFilePth := range opts.TestRunLogFilePaths {
+		idx++
+
+		testName := fmt.Sprintf("Test run #%d (%s)", idx, pkg)
+		testName = s.testaddonExporter.ReplaceUnsupportedFilenameCharacters(testName)
+
+		testRunLogFile, err := s.fileManager.Open(testRunLogFilePth)
+		if err != nil {
+			return fmt.Errorf("failed to open test run log file: %w", err)
+		}
+
+		report, err := gotest.NewParser().Parse(testRunLogFile)
+		if err != nil {
+			return fmt.Errorf("failed to parse go test report: %w", err)
+		}
+		reportFile, err := s.testaddonExporter.PrepareTestResultExport(testName)
+		if err != nil {
+			return fmt.Errorf("failed to prepare test result export: %w", err)
+		}
+
+		testsuits := junit.CreateFromReport(report, "")
+		if err := testsuits.WriteXML(reportFile); err != nil {
+			return fmt.Errorf("failed to write test report: %w", err)
+		}
+		s.logger.Printf("\nTest report is available at: %s", reportFile.Name())
+	}
+
 	return nil
+}
+
+func (s GoTestRunner) testRunLogTmpFile() (*os.File, error) {
+	tmpDir, err := s.pathProvider.CreateTempDir("go-test")
+	if err != nil {
+		return nil, fmt.Errorf("failed to create tmp dir for test run logs: %w", err)
+	}
+	pth := filepath.Join(tmpDir, "test_run.log")
+
+	f, err := s.fileManager.Create(pth)
+	if err != nil {
+		return nil, err
+	}
+
+	return f, nil
 }
 
 func (s GoTestRunner) createPackageCodeCoverageFile() (string, error) {

--- a/step/step.go
+++ b/step/step.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	"github.com/bitrise-io/go-steputils/v2/stepconf"
@@ -20,13 +21,15 @@ import (
 )
 
 type Inputs struct {
-	Packages  string `env:"packages,required"`
-	OutputDir string `env:"output_dir,required"`
+	Packages       string `env:"packages,required"`
+	OutputDir      string `env:"output_dir,required"`
+	TestReportName string `env:"test_report_name"`
 }
 
 type Config struct {
-	Packages  []string
-	OutputDir string
+	Packages                  []string
+	OutputDir                 string
+	PackagesToTestReportNames map[string]string
 }
 
 type GoTestRunner struct {
@@ -62,27 +65,25 @@ func NewGoTestRunner(
 	}
 }
 
-func (s GoTestRunner) ProcessInputs() (Config, error) {
+func (s GoTestRunner) ProcessInputs() (*Config, error) {
 	var inputs Inputs
 	if err := s.inputParser.Parse(&inputs); err != nil {
-		return Config{}, fmt.Errorf("issue with input: %w", err)
+		return nil, fmt.Errorf("issue with input: %w", err)
 	}
 
 	stepconf.Print(inputs)
 	s.logger.Println()
 
-	var packages []string
-	packagesSplit := strings.Split(inputs.Packages, "\n")
-	for _, p := range packagesSplit {
-		p = strings.TrimSpace(p)
-		if p != "" {
-			packages = append(packages, p)
-		}
+	packages := s.parsePackages(inputs.Packages)
+	packagesToTestReportNames, err := s.parseTestReportNameMapping(inputs.TestReportName, packages)
+	if err != nil {
+		return nil, err
 	}
 
-	return Config{
-		Packages:  packages,
-		OutputDir: inputs.OutputDir,
+	return &Config{
+		Packages:                  packages,
+		OutputDir:                 inputs.OutputDir,
+		PackagesToTestReportNames: packagesToTestReportNames,
 	}, nil
 }
 
@@ -146,8 +147,9 @@ func (s GoTestRunner) Run(opts RunOpts) (*RunResult, error) {
 }
 
 type ExportOpts struct {
-	CodeCoveragePth     string
-	TestRunLogFilePaths map[string]string
+	CodeCoveragePth           string
+	TestRunLogFilePaths       map[string]string
+	PackagesToTestReportNames map[string]string
 }
 
 func (s GoTestRunner) ExportOutput(opts ExportOpts) error {
@@ -171,7 +173,12 @@ func (s GoTestRunner) ExportOutput(opts ExportOpts) error {
 			return fmt.Errorf("failed to parse go test report: %w", parseErr)
 		}
 
-		reportFile, err := s.testaddonExporter.PrepareTestResultExport(pkg)
+		reportName, ok := opts.PackagesToTestReportNames[pkg]
+		if !ok {
+			reportName = pkg
+		}
+
+		reportFile, err := s.testaddonExporter.PrepareTestResultExport(reportName)
 		if err != nil {
 			return fmt.Errorf("failed to prepare test result export: %w", err)
 		}
@@ -185,6 +192,74 @@ func (s GoTestRunner) ExportOutput(opts ExportOpts) error {
 	}
 
 	return nil
+}
+
+func (s GoTestRunner) parsePackages(packages string) []string {
+	var pkgs []string
+	split := strings.Split(packages, "\n")
+	for _, pkg := range split {
+		pkg = strings.TrimSpace(pkg)
+		if pkg == "" {
+			continue
+		}
+
+		if slices.Contains(pkgs, pkg) {
+			s.logger.Warnf("Skipping duplicate package: %s", pkg)
+			continue
+		}
+
+		pkgs = append(pkgs, pkg)
+	}
+	return pkgs
+}
+
+func (s GoTestRunner) parseTestReportNameMapping(testReportName string, packages []string) (map[string]string, error) {
+	testReportName = strings.TrimSpace(testReportName)
+
+	packagesToTestReportName := map[string]string{}
+	testReportNameSplit := strings.Split(testReportName, "\n")
+	for _, line := range testReportNameSplit {
+		pkg, reportName := s.parseTestReportNameMappingLine(line)
+		if pkg == "" {
+			if len(testReportNameSplit) > 1 {
+				return nil, fmt.Errorf("invalid test report name mapping format: multiple mapping defined, but package name is missing from: %s", line)
+			}
+			if len(packages) > 1 {
+				return nil, errors.New("invalid test report name mapping format: single report name can't be assigned to multiple packages")
+			}
+			return map[string]string{packages[0]: reportName}, nil
+		}
+
+		if !slices.Contains(packages, pkg) {
+			return nil, fmt.Errorf("invalid test report name mapping format: package not found in packages: %s", pkg)
+		}
+
+		if _, ok := packagesToTestReportName[pkg]; ok {
+			return nil, fmt.Errorf("invalid test report name mapping format: duplicate package name: %s", pkg)
+		}
+
+		packagesToTestReportName[pkg] = reportName
+	}
+
+	return packagesToTestReportName, nil
+}
+
+func (s GoTestRunner) parseTestReportNameMappingLine(line string) (string, string) {
+	line = strings.TrimSpace(line)
+	if line == "" {
+		return "", ""
+	}
+
+	split := strings.Split(line, ":")
+	if len(split) == 0 {
+		return "", ""
+	}
+
+	if len(split) == 1 {
+		return "", strings.TrimSpace(split[0])
+	} else {
+		return strings.TrimSpace(split[0]), strings.TrimSpace(strings.Join(split[1:], ":"))
+	}
 }
 
 func (s GoTestRunner) testRunLogTmpFile() (*os.File, error) {

--- a/step/step.go
+++ b/step/step.go
@@ -18,18 +18,21 @@ import (
 	"github.com/bitrise-steplib/steps-go-test/testaddon"
 	"github.com/jstemmer/go-junit-report/v2/junit"
 	"github.com/jstemmer/go-junit-report/v2/parser/gotest"
+	shellquote "github.com/kballard/go-shellquote"
 )
 
 type Inputs struct {
 	Packages       string `env:"packages,required"`
-	OutputDir      string `env:"output_dir,required"`
+	TestOptions    string `env:"test_options"`
 	TestReportName string `env:"test_report_name"`
+	OutputDir      string `env:"output_dir,required"`
 }
 
 type Config struct {
 	Packages                  []string
-	OutputDir                 string
+	TestOptions               []string
 	PackagesToTestReportNames map[string]string
+	OutputDir                 string
 }
 
 type GoTestRunner struct {
@@ -80,16 +83,23 @@ func (s GoTestRunner) ProcessInputs() (*Config, error) {
 		return nil, err
 	}
 
+	testOptions, err := shellquote.Split(inputs.TestOptions)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse test options: %w", err)
+	}
+
 	return &Config{
 		Packages:                  packages,
-		OutputDir:                 inputs.OutputDir,
+		TestOptions:               testOptions,
 		PackagesToTestReportNames: packagesToTestReportNames,
+		OutputDir:                 inputs.OutputDir,
 	}, nil
 }
 
 type RunOpts struct {
-	Packages  []string
-	OutputDir string
+	Packages    []string
+	TestOptions []string
+	OutputDir   string
 }
 
 type RunResult struct {
@@ -119,7 +129,12 @@ func (s GoTestRunner) Run(opts RunOpts) (*RunResult, error) {
 		outWriter := io.MultiWriter(os.Stdout, logFile)
 		errWriter := io.MultiWriter(os.Stderr, logFile)
 
-		cmd := s.cmdFactory.Create("go", []string{"test", "-v", "-race", "-coverprofile=" + packageCodeCoveragePth, "-covermode=atomic", pkg}, &command.Opts{
+		args := []string{"test", "-v", "-race", "-coverprofile=" + packageCodeCoveragePth, "-covermode=atomic"}
+		if len(opts.TestOptions) > 0 {
+			args = append(args, opts.TestOptions...)
+		}
+		args = append(args, pkg)
+		cmd := s.cmdFactory.Create("go", args, &command.Opts{
 			Stdout: outWriter,
 			Stderr: errWriter,
 		})

--- a/step/step.go
+++ b/step/step.go
@@ -1,12 +1,10 @@
 package step
 
 import (
-	"errors"
 	"fmt"
 	"io"
 	"os"
 	"path/filepath"
-	"slices"
 	"strings"
 
 	"github.com/bitrise-io/go-steputils/v2/stepconf"
@@ -22,17 +20,17 @@ import (
 )
 
 type Inputs struct {
-	Packages       string `env:"packages,required"`
+	Package        string `env:"package,required"`
 	TestOptions    string `env:"test_options"`
 	TestReportName string `env:"test_report_name"`
 	OutputDir      string `env:"output_dir,required"`
 }
 
 type Config struct {
-	Packages                  []string
-	TestOptions               []string
-	PackagesToTestReportNames map[string]string
-	OutputDir                 string
+	Package        string
+	TestOptions    []string
+	TestReportName string
+	OutputDir      string
 }
 
 type GoTestRunner struct {
@@ -43,7 +41,7 @@ type GoTestRunner struct {
 	outputExporter    OutputExporter
 	pathProvider      pathutil.PathProvider
 	fileManager       filemanager.FileManager
-	testaddonExporter testaddon.Exporter
+	testAddonExporter testaddon.Exporter
 }
 
 func NewGoTestRunner(
@@ -54,7 +52,7 @@ func NewGoTestRunner(
 	outputExporter OutputExporter,
 	pathProvider pathutil.PathProvider,
 	fileManager filemanager.FileManager,
-	testaddonExporter testaddon.Exporter,
+	testAddonExporter testaddon.Exporter,
 ) GoTestRunner {
 	return GoTestRunner{
 		logger:            logger,
@@ -64,7 +62,7 @@ func NewGoTestRunner(
 		outputExporter:    outputExporter,
 		pathProvider:      pathProvider,
 		fileManager:       fileManager,
-		testaddonExporter: testaddonExporter,
+		testAddonExporter: testAddonExporter,
 	}
 }
 
@@ -77,213 +75,128 @@ func (s GoTestRunner) ProcessInputs() (*Config, error) {
 	stepconf.Print(inputs)
 	s.logger.Println()
 
-	packages := s.parsePackages(inputs.Packages)
-	packagesToTestReportNames, err := s.parseTestReportNameMapping(inputs.TestReportName, packages)
-	if err != nil {
-		return nil, err
-	}
-
+	pkg := strings.TrimSpace(inputs.Package)
+	testReportName := strings.TrimSpace(inputs.TestReportName)
 	testOptions, err := shellquote.Split(inputs.TestOptions)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse test options: %w", err)
 	}
 
 	return &Config{
-		Packages:                  packages,
-		TestOptions:               testOptions,
-		PackagesToTestReportNames: packagesToTestReportNames,
-		OutputDir:                 inputs.OutputDir,
+		Package:        pkg,
+		TestOptions:    testOptions,
+		TestReportName: testReportName,
+		OutputDir:      inputs.OutputDir,
 	}, nil
 }
 
 type RunOpts struct {
-	Packages    []string
+	Package     string
 	TestOptions []string
 	OutputDir   string
 }
 
 type RunResult struct {
-	CodeCoveragePth     string
-	TestRunLogFilePaths map[string]string
+	CodeCoveragePth string
+	TestRunLogPath  string
 }
 
 func (s GoTestRunner) Run(opts RunOpts) (*RunResult, error) {
-	packageCodeCoveragePth, err := s.createPackageCodeCoverageFile()
+	codeCoverageFile, err := s.createCodeCoverageFile(opts.OutputDir)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create package code coverage file: %w", err)
 	}
+	defer func() {
+		if err := codeCoverageFile.Close(); err != nil {
+			s.logger.Warnf("Failed to close code coverage file: %s", err)
+		}
+	}()
 
-	codeCoveragePth, err := s.codeCoveragePath(opts.OutputDir)
+	testRunLogFile, err := s.testRunLogFile(opts.OutputDir)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get code coverage path: %w", err)
+		return nil, fmt.Errorf("failed to create tmp file for test run logs: %w", err)
 	}
-
-	testRunLogFilePaths := map[string]string{}
-
-	for _, pkg := range opts.Packages {
-		logFile, err := s.testRunLogTmpFile()
-		if err != nil {
-			return nil, fmt.Errorf("failed to create tmp file for test run logs: %w", err)
-		}
-
-		outWriter := io.MultiWriter(os.Stdout, logFile)
-		errWriter := io.MultiWriter(os.Stderr, logFile)
-
-		args := []string{"test", "-v", "-race", "-coverprofile=" + packageCodeCoveragePth, "-covermode=atomic"}
-		if len(opts.TestOptions) > 0 {
-			args = append(args, opts.TestOptions...)
-		}
-		args = append(args, pkg)
-		cmd := s.cmdFactory.Create("go", args, &command.Opts{
-			Stdout: outWriter,
-			Stderr: errWriter,
-		})
-		s.logger.Printf("$ %s", cmd.PrintableCommandArgs())
-
-		testRunErr := cmd.Run()
-		if err := logFile.Close(); err != nil {
-			s.logger.Warnf("Failed to close test run log file: %s", err)
-		}
-		if testRunErr != nil {
-			return nil, fmt.Errorf("go test failed: %w", testRunErr)
-		}
-
-		if err := s.appendPackageCoverageAndRecreate(packageCodeCoveragePth, codeCoveragePth); err != nil {
-			return nil, fmt.Errorf("failed to append package coverage: %w", err)
-		}
-
-		testRunLogFilePaths[pkg] = logFile.Name()
-	}
-
-	return &RunResult{
-		CodeCoveragePth:     codeCoveragePth,
-		TestRunLogFilePaths: testRunLogFilePaths,
-	}, nil
-}
-
-type ExportOpts struct {
-	CodeCoveragePth           string
-	TestRunLogFilePaths       map[string]string
-	PackagesToTestReportNames map[string]string
-}
-
-func (s GoTestRunner) ExportOutput(opts ExportOpts) error {
-	if err := s.outputExporter.ExportOutput("GO_CODE_COVERAGE_REPORT_PATH", opts.CodeCoveragePth); err != nil {
-		return fmt.Errorf("failed to export GO_CODE_COVERAGE_REPORT_PATH=%s: %w", opts.CodeCoveragePth, err)
-	}
-
-	s.logger.Donef("\ncode coverage is available at: GO_CODE_COVERAGE_REPORT_PATH=%s", opts.CodeCoveragePth)
-
-	for pkg, testRunLogFilePth := range opts.TestRunLogFilePaths {
-		testRunLogFile, err := s.fileManager.Open(testRunLogFilePth)
-		if err != nil {
-			return fmt.Errorf("failed to open test run log file: %w", err)
-		}
-
-		report, parseErr := gotest.NewParser().Parse(testRunLogFile)
+	defer func() {
 		if err := testRunLogFile.Close(); err != nil {
 			s.logger.Warnf("Failed to close test run log file: %s", err)
 		}
-		if parseErr != nil {
-			return fmt.Errorf("failed to parse go test report: %w", parseErr)
-		}
+	}()
 
-		reportName, ok := opts.PackagesToTestReportNames[pkg]
-		if !ok {
-			reportName = pkg
-		}
+	outWriter := io.MultiWriter(os.Stdout, testRunLogFile)
+	errWriter := io.MultiWriter(os.Stderr, testRunLogFile)
 
-		reportFile, err := s.testaddonExporter.PrepareTestResultExport(reportName)
-		if err != nil {
-			return fmt.Errorf("failed to prepare test result export: %w", err)
-		}
-
-		testsuits := junit.CreateFromReport(report, "")
-		if err := testsuits.WriteXML(reportFile); err != nil {
-			return fmt.Errorf("failed to write test report: %w", err)
-		}
-
-		s.logger.Printf("\nTest report is available at: %s", reportFile.Name())
+	args := []string{"test", "-v", "-coverprofile=" + codeCoverageFile.Name(), "-covermode=atomic"}
+	if len(opts.TestOptions) > 0 {
+		args = append(args, opts.TestOptions...)
 	}
+	args = append(args, opts.Package)
+
+	cmd := s.cmdFactory.Create("go", args, &command.Opts{
+		Stdout: outWriter,
+		Stderr: errWriter,
+	})
+	s.logger.Printf("$ %s", cmd.PrintableCommandArgs())
+
+	return &RunResult{
+		CodeCoveragePth: codeCoverageFile.Name(),
+		TestRunLogPath:  testRunLogFile.Name(),
+	}, cmd.Run()
+}
+
+type ExportOpts struct {
+	TestRunLogPth   string
+	CodeCoveragePth string
+	TestReportName  string
+}
+
+func (s GoTestRunner) ExportOutput(opts ExportOpts) error {
+	if err := s.outputExporter.ExportOutput("GO_TEST_RUN_LOG_PATH", opts.TestRunLogPth); err != nil {
+		return fmt.Errorf("failed to export GO_TEST_RUN_LOG_PATH=%s: %w", opts.TestRunLogPth, err)
+	}
+	s.logger.Donef("\ngo test run log file is available at: GO_TEST_RUN_LOG_PATH=%s", opts.TestRunLogPth)
+
+	if err := s.outputExporter.ExportOutput("GO_CODE_COVERAGE_REPORT_PATH", opts.CodeCoveragePth); err != nil {
+		return fmt.Errorf("failed to export GO_CODE_COVERAGE_REPORT_PATH=%s: %w", opts.CodeCoveragePth, err)
+	}
+	s.logger.Donef("code coverage file is available at: GO_CODE_COVERAGE_REPORT_PATH=%s", opts.CodeCoveragePth)
+
+	testRunLogFile, err := s.fileManager.Open(opts.TestRunLogPth)
+	if err != nil {
+		return fmt.Errorf("failed to open test run log file: %w", err)
+	}
+	defer func() {
+		if err := testRunLogFile.Close(); err != nil {
+			s.logger.Warnf("Failed to close test run log file: %s", err)
+		}
+	}()
+
+	report, err := gotest.NewParser().Parse(testRunLogFile)
+	if err != nil {
+		return fmt.Errorf("failed to parse go test report: %w", err)
+	}
+
+	reportFile, err := s.testAddonExporter.PrepareTestResultExport(opts.TestReportName)
+	if err != nil {
+		return fmt.Errorf("failed to prepare test result export: %w", err)
+	}
+
+	testSuits := junit.CreateFromReport(report, "")
+	if err := testSuits.WriteXML(reportFile); err != nil {
+		return fmt.Errorf("failed to write test report: %w", err)
+	}
+
+	s.logger.Donef("test report exported, report file is available at: %s", reportFile.Name())
 
 	return nil
 }
 
-func (s GoTestRunner) parsePackages(packages string) []string {
-	var pkgs []string
-	split := strings.Split(packages, "\n")
-	for _, pkg := range split {
-		pkg = strings.TrimSpace(pkg)
-		if pkg == "" {
-			continue
-		}
-
-		if slices.Contains(pkgs, pkg) {
-			s.logger.Warnf("Skipping duplicate package: %s", pkg)
-			continue
-		}
-
-		pkgs = append(pkgs, pkg)
-	}
-	return pkgs
-}
-
-func (s GoTestRunner) parseTestReportNameMapping(testReportName string, packages []string) (map[string]string, error) {
-	testReportName = strings.TrimSpace(testReportName)
-
-	packagesToTestReportName := map[string]string{}
-	testReportNameSplit := strings.Split(testReportName, "\n")
-	for _, line := range testReportNameSplit {
-		pkg, reportName := s.parseTestReportNameMappingLine(line)
-		if pkg == "" {
-			if len(testReportNameSplit) > 1 {
-				return nil, fmt.Errorf("invalid test report name mapping format: multiple mapping defined, but package name is missing from: %s", line)
-			}
-			if len(packages) > 1 {
-				return nil, errors.New("invalid test report name mapping format: single report name can't be assigned to multiple packages")
-			}
-			return map[string]string{packages[0]: reportName}, nil
-		}
-
-		if !slices.Contains(packages, pkg) {
-			return nil, fmt.Errorf("invalid test report name mapping format: package not found in packages: %s", pkg)
-		}
-
-		if _, ok := packagesToTestReportName[pkg]; ok {
-			return nil, fmt.Errorf("invalid test report name mapping format: duplicate package name: %s", pkg)
-		}
-
-		packagesToTestReportName[pkg] = reportName
+func (s GoTestRunner) testRunLogFile(outputDir string) (*os.File, error) {
+	// TODO: do this earlier
+	if err := s.fileManager.MkdirAll(outputDir, 0777); err != nil {
+		return nil, fmt.Errorf("failed to create BITRISE_DEPLOY_DIR: %w", err)
 	}
 
-	return packagesToTestReportName, nil
-}
-
-func (s GoTestRunner) parseTestReportNameMappingLine(line string) (string, string) {
-	line = strings.TrimSpace(line)
-	if line == "" {
-		return "", ""
-	}
-
-	split := strings.Split(line, ":")
-	if len(split) == 0 {
-		return "", ""
-	}
-
-	if len(split) == 1 {
-		return "", strings.TrimSpace(split[0])
-	} else {
-		return strings.TrimSpace(split[0]), strings.TrimSpace(strings.Join(split[1:], ":"))
-	}
-}
-
-func (s GoTestRunner) testRunLogTmpFile() (*os.File, error) {
-	tmpDir, err := s.pathProvider.CreateTempDir("go-test")
-	if err != nil {
-		return nil, fmt.Errorf("failed to create tmp dir for test run logs: %w", err)
-	}
-	pth := filepath.Join(tmpDir, "test_run.log")
-
+	pth := filepath.Join(outputDir, "go_test_run.log")
 	f, err := s.fileManager.Create(pth)
 	if err != nil {
 		return nil, err
@@ -292,67 +205,17 @@ func (s GoTestRunner) testRunLogTmpFile() (*os.File, error) {
 	return f, nil
 }
 
-func (s GoTestRunner) createPackageCodeCoverageFile() (string, error) {
-	tmpDir, err := s.pathProvider.CreateTempDir("go-test")
-	if err != nil {
-		return "", fmt.Errorf("failed to create tmp dir for code coverage reports: %w", err)
-	}
-	pth := filepath.Join(tmpDir, "profile.out")
-
-	if _, err := s.fileManager.Create(pth); err != nil {
-		return "", err
-	}
-
-	return pth, nil
-}
-
-func (s GoTestRunner) codeCoveragePath(outputDir string) (string, error) {
+func (s GoTestRunner) createCodeCoverageFile(outputDir string) (*os.File, error) {
+	// TODO: do this earlier
 	if err := s.fileManager.MkdirAll(outputDir, 0777); err != nil {
-		return "", fmt.Errorf("failed to create BITRISE_DEPLOY_DIR: %w", err)
+		return nil, fmt.Errorf("failed to create BITRISE_DEPLOY_DIR: %w", err)
 	}
 
-	return filepath.Join(outputDir, "go_code_coverage.txt"), nil
-}
-
-func (s GoTestRunner) appendPackageCoverageAndRecreate(packageCoveragePth, coveragePth string) error {
-	// Read current package coverage report file
-	packageCoverageFile, err := s.fileManager.Open(packageCoveragePth)
+	pth := filepath.Join(outputDir, "go_code_coverage.out")
+	f, err := s.fileManager.Create(pth)
 	if err != nil {
-		return fmt.Errorf("failed to open package code coverage report file: %w", err)
-	}
-	packageCoverageFileContent, err := io.ReadAll(packageCoverageFile)
-	if err != nil {
-		return fmt.Errorf("failed to read package code coverage report file: %w", err)
+		return nil, err
 	}
 
-	// Append package coverage report to the main coverage report file
-	var coverageFileContent []byte
-	coverageFile, err := s.fileManager.Open(coveragePth)
-	if err != nil {
-		if !errors.Is(err, os.ErrNotExist) {
-			return fmt.Errorf("failed to open code coverage report file: %w", err)
-		}
-	} else {
-		coverageFileContent, err = io.ReadAll(coverageFile)
-		if err != nil {
-			return fmt.Errorf("failed to read code coverage report file: %w", err)
-		}
-	}
-
-	coverageFileContent = append(coverageFileContent, packageCoverageFileContent...)
-
-	if err := s.fileManager.Write(coveragePth, string(coverageFileContent), 0777); err != nil {
-		return fmt.Errorf("failed to write code coverage report file: %w", err)
-	}
-
-	// Recreate package coverage report file
-	if err := s.fileManager.RemoveAll(packageCoveragePth); err != nil {
-		return fmt.Errorf("failed to remove package code coverage report file: %w", err)
-	}
-
-	if _, err := s.fileManager.Create(packageCoveragePth); err != nil {
-		return fmt.Errorf("failed to create package code coverage report file: %w", err)
-	}
-
-	return nil
+	return f, nil
 }

--- a/step/step_test.go
+++ b/step/step_test.go
@@ -100,7 +100,7 @@ func TestGoTestRunner_Run_WhenTestFails(t *testing.T) {
 		fileManager:    mockFileManager,
 	}
 	gotResult, err := s.Run(opts)
-	require.EqualError(t, err, "exit status 1")
+	require.EqualError(t, err, "go test failed: exit status 1")
 	require.Equal(t, wantRunResult, gotResult)
 }
 

--- a/step/step_test.go
+++ b/step/step_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 
 	"github.com/bitrise-io/go-utils/v2/log"
@@ -23,7 +22,7 @@ func TestGoTestRunner_Run_WhenTestSucceedItWritesCodeCoverageToFile(t *testing.T
 	}
 
 	// Expected result
-	testRunLogFile := mockTestRunLogFile(t)
+	testRunLogFile := createTmpFile(t)
 	wantCoveragePth := filepath.Join(outputDir, "go_code_coverage.txt")
 	wantRunResult := &RunResult{
 		CodeCoveragePth:     wantCoveragePth,
@@ -45,13 +44,13 @@ func TestGoTestRunner_Run_WhenTestSucceedItWritesCodeCoverageToFile(t *testing.T
 
 	// It recreates package coverage file for every packages' go test command run
 	mockPathProvider.On("CreateTempDir", mock.Anything).Return(tmpDir, nil)
-	mockFileManager.On("Open", packageCoveragePth).Return(strings.NewReader(""), nil)
-	mockFileManager.On("Create", packageCoveragePth).Return(nil, nil)
+	mockFileManager.On("Open", packageCoveragePth).Return(createTmpFile(t), nil)
+	mockFileManager.On("Create", packageCoveragePth).Return(createTmpFile(t), nil)
 	mockFileManager.On("MkdirAll", outputDir, mock.Anything).Return(nil)
 	mockFileManager.On("RemoveAll", packageCoveragePth).Return(nil)
 
 	// It writes code coverage to file
-	mockFileManager.On("Open", wantCoveragePth).Return(strings.NewReader(""), nil)
+	mockFileManager.On("Open", wantCoveragePth).Return(createTmpFile(t), nil)
 	mockFileManager.On("Write", wantCoveragePth, mock.Anything, mock.Anything).Return(nil)
 
 	// It writes test run logs to a file
@@ -96,12 +95,12 @@ func TestGoTestRunner_Run_WhenTestFailsItReturnsAnError(t *testing.T) {
 
 	// It recreates package coverage file for every packages' go test command run
 	mockPathProvider.On("CreateTempDir", mock.Anything).Return(tmpDir, nil)
-	mockFileManager.On("Create", packageCoveragePth).Return(nil, nil)
+	mockFileManager.On("Create", packageCoveragePth).Return(createTmpFile(t), nil)
 	mockFileManager.On("MkdirAll", outputDir, mock.Anything).Return(nil)
 
 	// It writes test run logs to a file
 	testRunLogFile := filepath.Join(tmpDir, "test_run.log")
-	mockFileManager.On("Create", testRunLogFile).Return(nil, nil)
+	mockFileManager.On("Create", testRunLogFile).Return(createTmpFile(t), nil)
 
 	s := GoTestRunner{
 		logger:         log.NewLogger(),
@@ -117,9 +116,9 @@ func TestGoTestRunner_Run_WhenTestFailsItReturnsAnError(t *testing.T) {
 	require.Nil(t, gotResult)
 }
 
-func mockTestRunLogFile(t *testing.T) *os.File {
-	testRunLogFilePth := filepath.Join(t.TempDir(), "test_run.log")
-	f, err := os.Create(testRunLogFilePth)
+func createTmpFile(t *testing.T) *os.File {
+	tmpFilePth := filepath.Join(t.TempDir(), "test_run.log")
+	f, err := os.Create(tmpFilePth)
 	require.NoError(t, err)
 	return f
 }

--- a/step/step_test.go
+++ b/step/step_test.go
@@ -18,6 +18,7 @@ func TestGoTestRunner_Run_WhenTestSucceeds(t *testing.T) {
 	outputDir := t.TempDir()
 	opts := RunOpts{
 		Package:   pkg,
+		Covermode: "atomic",
 		OutputDir: outputDir,
 	}
 
@@ -36,7 +37,7 @@ func TestGoTestRunner_Run_WhenTestSucceeds(t *testing.T) {
 	mockPathProvider := mocks.NewPathProvider(t)
 
 	// It runs go test command with code coverage enabled
-	mockCmdFactory.On("Create", "go", []string{"test", "-v", "-coverprofile=" + codeCoverageFile.Name(), "-covermode=atomic", pkg}, mock.Anything).Return(mockCmd)
+	mockCmdFactory.On("Create", "go", []string{"test", "-v", "-covermode=atomic", "-coverprofile=" + codeCoverageFile.Name(), pkg}, mock.Anything).Return(mockCmd)
 	mockCmd.On("Run").Return(nil)
 	mockCmd.On("PrintableCommandArgs").Return("")
 
@@ -70,10 +71,8 @@ func TestGoTestRunner_Run_WhenTestFails(t *testing.T) {
 
 	// Expected result
 	testRunLogFile := createTmpFile(outputDir, "go_test_run.log", t)
-	codeCoverageFile := createTmpFile(outputDir, "go_code_coverage.out", t)
 	wantRunResult := &RunResult{
-		CodeCoveragePth: codeCoverageFile.Name(),
-		TestRunLogPath:  testRunLogFile.Name(),
+		TestRunLogPath: testRunLogFile.Name(),
 	}
 
 	// Create mocks
@@ -83,13 +82,12 @@ func TestGoTestRunner_Run_WhenTestFails(t *testing.T) {
 	mockPathProvider := mocks.NewPathProvider(t)
 
 	// It runs go test command with code coverage enabled
-	mockCmdFactory.On("Create", "go", []string{"test", "-v", "-coverprofile=" + codeCoverageFile.Name(), "-covermode=atomic", pkg}, mock.Anything).Return(mockCmd)
+	mockCmdFactory.On("Create", "go", []string{"test", "-v", pkg}, mock.Anything).Return(mockCmd)
 	mockCmd.On("Run").Return(fmt.Errorf("exit status 1"))
 	mockCmd.On("PrintableCommandArgs").Return("")
 
 	// It creates package coverage file and test run log file
 	mockFileManager.On("MkdirAll", outputDir, mock.Anything).Return(nil)
-	mockFileManager.On("Create", codeCoverageFile.Name()).Return(codeCoverageFile, nil)
 	mockFileManager.On("Create", testRunLogFile.Name()).Return(testRunLogFile, nil)
 
 	s := GoTestRunner{

--- a/step/step_test.go
+++ b/step/step_test.go
@@ -2,6 +2,7 @@ package step
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -22,9 +23,11 @@ func TestGoTestRunner_Run_WhenTestSucceedItWritesCodeCoverageToFile(t *testing.T
 	}
 
 	// Expected result
+	testRunLogFile := mockTestRunLogFile(t)
 	wantCoveragePth := filepath.Join(outputDir, "go_code_coverage.txt")
 	wantRunResult := &RunResult{
-		CodeCoveragePth: wantCoveragePth,
+		CodeCoveragePth:     wantCoveragePth,
+		TestRunLogFilePaths: map[string]string{"./...": testRunLogFile.Name()},
 	}
 
 	// Create mocks
@@ -50,6 +53,10 @@ func TestGoTestRunner_Run_WhenTestSucceedItWritesCodeCoverageToFile(t *testing.T
 	// It writes code coverage to file
 	mockFileManager.On("Open", wantCoveragePth).Return(strings.NewReader(""), nil)
 	mockFileManager.On("Write", wantCoveragePth, mock.Anything, mock.Anything).Return(nil)
+
+	// It writes test run logs to a file
+	testRunLogFilePth := filepath.Join(tmpDir, "test_run.log")
+	mockFileManager.On("Create", testRunLogFilePth).Return(testRunLogFile, nil)
 
 	s := GoTestRunner{
 		logger:         log.NewLogger(),
@@ -92,6 +99,10 @@ func TestGoTestRunner_Run_WhenTestFailsItReturnsAnError(t *testing.T) {
 	mockFileManager.On("Create", packageCoveragePth).Return(nil, nil)
 	mockFileManager.On("MkdirAll", outputDir, mock.Anything).Return(nil)
 
+	// It writes test run logs to a file
+	testRunLogFile := filepath.Join(tmpDir, "test_run.log")
+	mockFileManager.On("Create", testRunLogFile).Return(nil, nil)
+
 	s := GoTestRunner{
 		logger:         log.NewLogger(),
 		inputParser:    nil,
@@ -104,4 +115,11 @@ func TestGoTestRunner_Run_WhenTestFailsItReturnsAnError(t *testing.T) {
 	gotResult, err := s.Run(opts)
 	require.EqualError(t, err, "go test failed: exit status 1")
 	require.Nil(t, gotResult)
+}
+
+func mockTestRunLogFile(t *testing.T) *os.File {
+	testRunLogFilePth := filepath.Join(t.TempDir(), "test_run.log")
+	f, err := os.Create(testRunLogFilePth)
+	require.NoError(t, err)
+	return f
 }

--- a/step/step_test.go
+++ b/step/step_test.go
@@ -12,21 +12,21 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestGoTestRunner_Run_WhenTestSucceedItWritesCodeCoverageToFile(t *testing.T) {
+func TestGoTestRunner_Run_WhenTestSucceeds(t *testing.T) {
 	// Create run options
-	packages := []string{"./..."}
-	outputDir := "output"
+	pkg := "./..."
+	outputDir := t.TempDir()
 	opts := RunOpts{
-		Packages:  packages,
+		Package:   pkg,
 		OutputDir: outputDir,
 	}
 
 	// Expected result
-	testRunLogFile := createTmpFile(t)
-	wantCoveragePth := filepath.Join(outputDir, "go_code_coverage.txt")
+	testRunLogFile := createTmpFile(outputDir, "go_test_run.log", t)
+	codeCoverageFile := createTmpFile(outputDir, "go_code_coverage.out", t)
 	wantRunResult := &RunResult{
-		CodeCoveragePth:     wantCoveragePth,
-		TestRunLogFilePaths: map[string]string{"./...": testRunLogFile.Name()},
+		CodeCoveragePth: codeCoverageFile.Name(),
+		TestRunLogPath:  testRunLogFile.Name(),
 	}
 
 	// Create mocks
@@ -36,71 +36,14 @@ func TestGoTestRunner_Run_WhenTestSucceedItWritesCodeCoverageToFile(t *testing.T
 	mockPathProvider := mocks.NewPathProvider(t)
 
 	// It runs go test command with code coverage enabled
-	tmpDir := "tmp_dir"
-	packageCoveragePth := filepath.Join(tmpDir, "profile.out")
-	mockCmdFactory.On("Create", "go", []string{"test", "-v", "-race", "-coverprofile=" + packageCoveragePth, "-covermode=atomic", packages[0]}, mock.Anything).Return(mockCmd)
+	mockCmdFactory.On("Create", "go", []string{"test", "-v", "-coverprofile=" + codeCoverageFile.Name(), "-covermode=atomic", pkg}, mock.Anything).Return(mockCmd)
 	mockCmd.On("Run").Return(nil)
 	mockCmd.On("PrintableCommandArgs").Return("")
 
-	// It recreates package coverage file for every packages' go test command run
-	mockPathProvider.On("CreateTempDir", mock.Anything).Return(tmpDir, nil)
-	mockFileManager.On("Open", packageCoveragePth).Return(createTmpFile(t), nil)
-	mockFileManager.On("Create", packageCoveragePth).Return(createTmpFile(t), nil)
+	// It creates package coverage file and test run log file
 	mockFileManager.On("MkdirAll", outputDir, mock.Anything).Return(nil)
-	mockFileManager.On("RemoveAll", packageCoveragePth).Return(nil)
-
-	// It writes code coverage to file
-	mockFileManager.On("Open", wantCoveragePth).Return(createTmpFile(t), nil)
-	mockFileManager.On("Write", wantCoveragePth, mock.Anything, mock.Anything).Return(nil)
-
-	// It writes test run logs to a file
-	testRunLogFilePth := filepath.Join(tmpDir, "test_run.log")
-	mockFileManager.On("Create", testRunLogFilePth).Return(testRunLogFile, nil)
-
-	s := GoTestRunner{
-		logger:         log.NewLogger(),
-		inputParser:    nil,
-		envRepo:        nil,
-		cmdFactory:     mockCmdFactory,
-		outputExporter: nil,
-		pathProvider:   mockPathProvider,
-		fileManager:    mockFileManager,
-	}
-	runResult, err := s.Run(opts)
-	require.NoError(t, err)
-	require.Equal(t, wantRunResult, runResult)
-}
-
-func TestGoTestRunner_Run_WhenTestFailsItReturnsAnError(t *testing.T) {
-	// Create run options
-	packages := []string{"./..."}
-	outputDir := "output"
-	opts := RunOpts{
-		Packages:  packages,
-		OutputDir: outputDir,
-	}
-
-	// Create mocks
-	mockCmdFactory := mocks.NewFactory(t)
-	mockCmd := mocks.NewCommand(t)
-	mockFileManager := mocks.NewFileManager(t)
-	mockPathProvider := mocks.NewPathProvider(t)
-
-	// It runs go test command with code coverage enabled
-	tmpDir := "tmp_dir"
-	packageCoveragePth := filepath.Join(tmpDir, "profile.out")
-	mockCmdFactory.On("Create", "go", []string{"test", "-v", "-race", "-coverprofile=" + packageCoveragePth, "-covermode=atomic", packages[0]}, mock.Anything).Return(mockCmd)
-	mockCmd.On("Run").Return(fmt.Errorf("exit status 1"))
-	mockCmd.On("PrintableCommandArgs").Return("")
-
-	// It recreates package coverage file for every packages' go test command run
-	mockPathProvider.On("CreateTempDir", mock.Anything).Return(tmpDir, nil)
-	mockFileManager.On("Create", packageCoveragePth).Return(createTmpFile(t), nil)
-	mockFileManager.On("MkdirAll", outputDir, mock.Anything).Return(nil)
-
-	// It writes test run logs to a file
-	testRunLogFile := filepath.Join(tmpDir, "test_run.log")
-	mockFileManager.On("Create", testRunLogFile).Return(createTmpFile(t), nil)
+	mockFileManager.On("Create", codeCoverageFile.Name()).Return(codeCoverageFile, nil)
+	mockFileManager.On("Create", testRunLogFile.Name()).Return(testRunLogFile, nil)
 
 	s := GoTestRunner{
 		logger:         log.NewLogger(),
@@ -112,12 +55,59 @@ func TestGoTestRunner_Run_WhenTestFailsItReturnsAnError(t *testing.T) {
 		fileManager:    mockFileManager,
 	}
 	gotResult, err := s.Run(opts)
-	require.EqualError(t, err, "go test failed: exit status 1")
-	require.Nil(t, gotResult)
+	require.NoError(t, err)
+	require.Equal(t, wantRunResult, gotResult)
 }
 
-func createTmpFile(t *testing.T) *os.File {
-	tmpFilePth := filepath.Join(t.TempDir(), "test_run.log")
+func TestGoTestRunner_Run_WhenTestFails(t *testing.T) {
+	// Create run options
+	pkg := "./..."
+	outputDir := t.TempDir()
+	opts := RunOpts{
+		Package:   pkg,
+		OutputDir: outputDir,
+	}
+
+	// Expected result
+	testRunLogFile := createTmpFile(outputDir, "go_test_run.log", t)
+	codeCoverageFile := createTmpFile(outputDir, "go_code_coverage.out", t)
+	wantRunResult := &RunResult{
+		CodeCoveragePth: codeCoverageFile.Name(),
+		TestRunLogPath:  testRunLogFile.Name(),
+	}
+
+	// Create mocks
+	mockCmdFactory := mocks.NewFactory(t)
+	mockCmd := mocks.NewCommand(t)
+	mockFileManager := mocks.NewFileManager(t)
+	mockPathProvider := mocks.NewPathProvider(t)
+
+	// It runs go test command with code coverage enabled
+	mockCmdFactory.On("Create", "go", []string{"test", "-v", "-coverprofile=" + codeCoverageFile.Name(), "-covermode=atomic", pkg}, mock.Anything).Return(mockCmd)
+	mockCmd.On("Run").Return(fmt.Errorf("exit status 1"))
+	mockCmd.On("PrintableCommandArgs").Return("")
+
+	// It creates package coverage file and test run log file
+	mockFileManager.On("MkdirAll", outputDir, mock.Anything).Return(nil)
+	mockFileManager.On("Create", codeCoverageFile.Name()).Return(codeCoverageFile, nil)
+	mockFileManager.On("Create", testRunLogFile.Name()).Return(testRunLogFile, nil)
+
+	s := GoTestRunner{
+		logger:         log.NewLogger(),
+		inputParser:    nil,
+		envRepo:        nil,
+		cmdFactory:     mockCmdFactory,
+		outputExporter: nil,
+		pathProvider:   mockPathProvider,
+		fileManager:    mockFileManager,
+	}
+	gotResult, err := s.Run(opts)
+	require.EqualError(t, err, "exit status 1")
+	require.Equal(t, wantRunResult, gotResult)
+}
+
+func createTmpFile(tmpDir string, name string, t *testing.T) *os.File {
+	tmpFilePth := filepath.Join(tmpDir, name)
 	f, err := os.Create(tmpFilePth)
 	require.NoError(t, err)
 	return f

--- a/step/utils.go
+++ b/step/utils.go
@@ -1,52 +1,7 @@
 package step
 
-import (
-	"io"
-	"os"
-
-	"github.com/bitrise-io/go-utils/v2/fileutil"
-)
-
 // OutputExporter ...
 // TODO: export.NewExporter should return an interface
 type OutputExporter interface {
 	ExportOutput(key, value string) error
-}
-
-// FileManager ...
-// TODO: fileutil.FileManager interface should be extended with more methods
-type FileManager interface {
-	Create(name string) (*os.File, error)
-	MkdirAll(path string, perm os.FileMode) error
-	Open(path string) (io.Reader, error)
-	Write(path string, value string, perm os.FileMode) error
-	RemoveAll(path string) error
-}
-
-type fileManager struct {
-	fileManager fileutil.FileManager
-}
-
-func NewFileManager(manager fileutil.FileManager) FileManager {
-	return fileManager{fileManager: manager}
-}
-
-func (f fileManager) Create(name string) (*os.File, error) {
-	return os.Create(name)
-}
-
-func (f fileManager) MkdirAll(path string, perm os.FileMode) error {
-	return os.MkdirAll(path, perm)
-}
-
-func (f fileManager) Open(path string) (io.Reader, error) {
-	return f.fileManager.Open(path)
-}
-
-func (f fileManager) Write(path string, value string, perm os.FileMode) error {
-	return f.fileManager.Write(path, value, perm)
-}
-
-func (f fileManager) RemoveAll(path string) error {
-	return f.fileManager.RemoveAll(path)
 }

--- a/testaddon/testaddon.go
+++ b/testaddon/testaddon.go
@@ -1,0 +1,75 @@
+package testaddon
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/bitrise-io/go-utils/v2/env"
+	"github.com/bitrise-steplib/steps-go-test/filemanager"
+)
+
+const (
+	resultDescriptorFileName = "test-info.json"
+)
+
+// TestInfo ...
+type TestInfo struct {
+	Name string `json:"test-name" yaml:"test-name"` // Test name
+}
+
+type Exporter interface {
+	PrepareTestResultExport(testName string) (*os.File, error)
+	ReplaceUnsupportedFilenameCharacters(s string) string
+}
+
+type exporter struct {
+	envRepo     env.Repository
+	fileManager filemanager.FileManager
+}
+
+func NewExporter(envRepo env.Repository, fileManager filemanager.FileManager) Exporter {
+	return exporter{
+		envRepo:     envRepo,
+		fileManager: fileManager,
+	}
+}
+
+func (e exporter) ReplaceUnsupportedFilenameCharacters(s string) string {
+	s = strings.ReplaceAll(s, "/", "-")
+	s = strings.ReplaceAll(s, ":", "-")
+	return s
+}
+
+func (e exporter) PrepareTestResultExport(testName string) (*os.File, error) {
+	testInfo := &TestInfo{
+		Name: testName,
+	}
+
+	stepTestResultDir := e.envRepo.Get("BITRISE_TEST_RESULT_DIR")
+	testResultDir := filepath.Join(stepTestResultDir, testName)
+
+	if err := e.fileManager.MkdirAll(testResultDir, os.ModePerm); err != nil {
+		return nil, err
+	}
+
+	bytes, err := json.Marshal(testInfo)
+	if err != nil {
+		return nil, err
+	}
+
+	testInfoPath := filepath.Join(testResultDir, resultDescriptorFileName)
+	if err := e.fileManager.Write(testInfoPath, string(bytes), os.ModePerm); err != nil {
+		return nil, err
+	}
+
+	testReportFilePth := filepath.Join(testResultDir, fmt.Sprintf("%s-test_report.xml", testName))
+	testReportFile, err := e.fileManager.Create(testReportFilePth)
+	if err != nil {
+		return nil, err
+	}
+
+	return testReportFile, nil
+}

--- a/testaddon/testaddon.go
+++ b/testaddon/testaddon.go
@@ -2,7 +2,6 @@ package testaddon
 
 import (
 	"encoding/json"
-	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -22,7 +21,6 @@ type TestInfo struct {
 
 type Exporter interface {
 	PrepareTestResultExport(testName string) (*os.File, error)
-	ReplaceUnsupportedFilenameCharacters(s string) string
 }
 
 type exporter struct {
@@ -37,19 +35,14 @@ func NewExporter(envRepo env.Repository, fileManager filemanager.FileManager) Ex
 	}
 }
 
-func (e exporter) ReplaceUnsupportedFilenameCharacters(s string) string {
-	s = strings.ReplaceAll(s, "/", "-")
-	s = strings.ReplaceAll(s, ":", "-")
-	return s
-}
-
 func (e exporter) PrepareTestResultExport(testName string) (*os.File, error) {
 	testInfo := &TestInfo{
 		Name: testName,
 	}
 
 	stepTestResultDir := e.envRepo.Get("BITRISE_TEST_RESULT_DIR")
-	testResultDir := filepath.Join(stepTestResultDir, testName)
+	testResultFileName := replaceUnsupportedFilenameCharacters(testName)
+	testResultDir := filepath.Join(stepTestResultDir, testResultFileName)
 
 	if err := e.fileManager.MkdirAll(testResultDir, os.ModePerm); err != nil {
 		return nil, err
@@ -65,11 +58,17 @@ func (e exporter) PrepareTestResultExport(testName string) (*os.File, error) {
 		return nil, err
 	}
 
-	testReportFilePth := filepath.Join(testResultDir, fmt.Sprintf("%s-test_report.xml", testName))
+	testReportFilePth := filepath.Join(testResultDir, "test_report.xml")
 	testReportFile, err := e.fileManager.Create(testReportFilePth)
 	if err != nil {
 		return nil, err
 	}
 
 	return testReportFile, nil
+}
+
+func replaceUnsupportedFilenameCharacters(s string) string {
+	s = strings.ReplaceAll(s, "/", "-")
+	s = strings.ReplaceAll(s, ":", "-")
+	return s
 }

--- a/testaddon/testaddon.go
+++ b/testaddon/testaddon.go
@@ -16,7 +16,7 @@ const (
 
 // TestInfo ...
 type TestInfo struct {
-	Name string `json:"test-name" yaml:"test-name"` // Test name
+	Name string `json:"test-name"`
 }
 
 type Exporter interface {

--- a/vendor/github.com/jstemmer/go-junit-report/v2/LICENSE
+++ b/vendor/github.com/jstemmer/go-junit-report/v2/LICENSE
@@ -1,0 +1,20 @@
+Copyright (c) 2012 Joel Stemmer
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/vendor/github.com/jstemmer/go-junit-report/v2/gtr/gtr.go
+++ b/vendor/github.com/jstemmer/go-junit-report/v2/gtr/gtr.go
@@ -1,0 +1,145 @@
+// Package gtr defines a standard test report format and provides convenience
+// methods to create and convert reports.
+package gtr
+
+import (
+	"strings"
+	"time"
+)
+
+// Result is the result of a test.
+type Result int
+
+// Test results.
+const (
+	Unknown Result = iota
+	Pass
+	Fail
+	Skip
+)
+
+func (r Result) String() string {
+	switch r {
+	case Unknown:
+		return "UNKNOWN"
+	case Pass:
+		return "PASS"
+	case Fail:
+		return "FAIL"
+	case Skip:
+		return "SKIP"
+	default:
+		panic("invalid Result")
+	}
+}
+
+// Report contains the build and test results of a collection of packages.
+type Report struct {
+	Packages []Package
+}
+
+// IsSuccessful returns true if none of the packages in this report have build
+// or runtime errors and all tests passed without failures or were skipped.
+func (r *Report) IsSuccessful() bool {
+	for _, pkg := range r.Packages {
+		if pkg.BuildError.Name != "" || pkg.RunError.Name != "" {
+			return false
+		}
+		for _, t := range pkg.Tests {
+			if t.Result != Pass && t.Result != Skip {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+// Package contains build and test results for a single package.
+type Package struct {
+	Name       string
+	Timestamp  time.Time
+	Duration   time.Duration
+	Coverage   float64
+	Output     []string
+	Properties []Property
+
+	Tests []Test
+
+	BuildError Error
+	RunError   Error
+}
+
+// SetProperty stores a key/value property in the current package. If a
+// property with the given key already exists, its old value will be
+// overwritten with the given value.
+func (p *Package) SetProperty(key, value string) {
+	// TODO(jstemmer): Delete this method in the next major release.
+	// Delete all the properties whose name is the specified key,
+	// then add the specified key-value property.
+	i := 0
+	for _, prop := range p.Properties {
+		if key != prop.Name {
+			p.Properties[i] = prop
+			i++
+		}
+	}
+	p.Properties = p.Properties[:i]
+	p.AddProperty(key, value)
+}
+
+// AddProperty appends a name/value property in the current package.
+func (p *Package) AddProperty(name, value string) {
+	p.Properties = append(p.Properties, Property{Name: name, Value: value})
+}
+
+// Property is a name/value property.
+type Property struct {
+	Name, Value string
+}
+
+// Test contains the results of a single test.
+type Test struct {
+	ID       int
+	Name     string
+	Duration time.Duration
+	Result   Result
+	Level    int
+	Output   []string
+	Data     map[string]interface{}
+}
+
+// NewTest creates a new Test with the given id and name.
+func NewTest(id int, name string) Test {
+	return Test{ID: id, Name: name, Data: make(map[string]interface{})}
+}
+
+// Error contains details of a build or runtime error.
+type Error struct {
+	ID       int
+	Name     string
+	Duration time.Duration
+	Cause    string
+	Output   []string
+}
+
+// TrimPrefixSpaces trims the leading whitespace of the given line using the
+// indentation level of the test. Printing logs in a Go test is typically
+// prepended by blocks of 4 spaces to align it with the rest of the test
+// output. TrimPrefixSpaces intends to only trim the whitespace added by the Go
+// test command, without inadvertently trimming whitespace added by the test
+// author.
+func TrimPrefixSpaces(line string, indent int) string {
+	// We only want to trim the whitespace prefix if it was part of the test
+	// output. Test output is usually prefixed by a series of 4-space indents,
+	// so we'll check for that to decide whether this output was likely to be
+	// from a test.
+	prefixLen := strings.IndexFunc(line, func(r rune) bool { return r != ' ' })
+	if prefixLen%4 == 0 {
+		// Use the subtest level to trim a consistently sized prefix from the
+		// output lines.
+		for i := 0; i <= indent; i++ {
+			line = strings.TrimPrefix(line, "    ")
+		}
+	}
+	return strings.TrimPrefix(line, "\t")
+}

--- a/vendor/github.com/jstemmer/go-junit-report/v2/junit/junit.go
+++ b/vendor/github.com/jstemmer/go-junit-report/v2/junit/junit.go
@@ -1,0 +1,277 @@
+// Package junit defines a JUnit XML report and includes convenience methods
+// for working with these reports.
+package junit
+
+import (
+	"encoding/xml"
+	"fmt"
+	"io"
+	"strings"
+	"time"
+
+	"github.com/jstemmer/go-junit-report/v2/gtr"
+)
+
+// Testsuites is a collection of JUnit testsuites.
+type Testsuites struct {
+	XMLName xml.Name `xml:"testsuites"`
+
+	Name     string `xml:"name,attr,omitempty"`
+	Time     string `xml:"time,attr,omitempty"` // total duration in seconds
+	Tests    int    `xml:"tests,attr,omitempty"`
+	Errors   int    `xml:"errors,attr,omitempty"`
+	Failures int    `xml:"failures,attr,omitempty"`
+	Skipped  int    `xml:"skipped,attr,omitempty"`
+	Disabled int    `xml:"disabled,attr,omitempty"`
+
+	Suites []Testsuite `xml:"testsuite,omitempty"`
+}
+
+// AddSuite adds a Testsuite and updates this testssuites' totals.
+func (t *Testsuites) AddSuite(ts Testsuite) {
+	t.Suites = append(t.Suites, ts)
+	t.Tests += ts.Tests
+	t.Errors += ts.Errors
+	t.Failures += ts.Failures
+	t.Skipped += ts.Skipped
+	t.Disabled += ts.Disabled
+}
+
+// WriteXML writes the XML representation of Testsuites t to writer w.
+func (t *Testsuites) WriteXML(w io.Writer) error {
+	enc := xml.NewEncoder(w)
+	enc.Indent("", "\t")
+	if err := enc.Encode(t); err != nil {
+		return err
+	}
+	if err := enc.Flush(); err != nil {
+		return err
+	}
+	_, err := fmt.Fprintf(w, "\n")
+	return err
+}
+
+// Testsuite is a single JUnit testsuite containing testcases.
+type Testsuite struct {
+	// required attributes
+	Name     string `xml:"name,attr"`
+	Tests    int    `xml:"tests,attr"`
+	Failures int    `xml:"failures,attr"`
+	Errors   int    `xml:"errors,attr"`
+	ID       int    `xml:"id,attr"`
+
+	// optional attributes
+	Disabled  int    `xml:"disabled,attr,omitempty"`
+	Hostname  string `xml:"hostname,attr,omitempty"`
+	Package   string `xml:"package,attr,omitempty"`
+	Skipped   int    `xml:"skipped,attr,omitempty"`
+	Time      string `xml:"time,attr"`                // duration in seconds
+	Timestamp string `xml:"timestamp,attr,omitempty"` // date and time in ISO8601
+	File      string `xml:"file,attr,omitempty"`
+
+	Properties *[]Property `xml:"properties>property,omitempty"`
+	Testcases  []Testcase  `xml:"testcase,omitempty"`
+	SystemOut  *Output     `xml:"system-out,omitempty"`
+	SystemErr  *Output     `xml:"system-err,omitempty"`
+}
+
+// AddProperty adds a property with the given name and value to this Testsuite.
+func (t *Testsuite) AddProperty(name, value string) {
+	prop := Property{Name: name, Value: value}
+	if t.Properties == nil {
+		t.Properties = &[]Property{prop}
+		return
+	}
+	props := append(*t.Properties, prop)
+	t.Properties = &props
+}
+
+// AddTestcase adds Testcase tc to this Testsuite.
+func (t *Testsuite) AddTestcase(tc Testcase) {
+	t.Testcases = append(t.Testcases, tc)
+	t.Tests++
+
+	if tc.Error != nil {
+		t.Errors++
+	}
+
+	if tc.Failure != nil {
+		t.Failures++
+	}
+
+	if tc.Skipped != nil {
+		t.Skipped++
+	}
+}
+
+// SetTimestamp sets the timestamp in this Testsuite.
+func (t *Testsuite) SetTimestamp(timestamp time.Time) {
+	t.Timestamp = timestamp.Format(time.RFC3339)
+}
+
+// Testcase represents a single test with its results.
+type Testcase struct {
+	// required attributes
+	Name      string `xml:"name,attr"`
+	Classname string `xml:"classname,attr"`
+
+	// optional attributes
+	Time   string `xml:"time,attr,omitempty"` // duration in seconds
+	Status string `xml:"status,attr,omitempty"`
+
+	Skipped   *Result `xml:"skipped,omitempty"`
+	Error     *Result `xml:"error,omitempty"`
+	Failure   *Result `xml:"failure,omitempty"`
+	SystemOut *Output `xml:"system-out,omitempty"`
+	SystemErr *Output `xml:"system-err,omitempty"`
+}
+
+// Property represents a key/value pair.
+type Property struct {
+	Name  string `xml:"name,attr"`
+	Value string `xml:"value,attr"`
+}
+
+// Result represents the result of a single test.
+type Result struct {
+	Message string `xml:"message,attr"`
+	Type    string `xml:"type,attr,omitempty"`
+	Data    string `xml:",cdata"`
+}
+
+// Output represents output written to stdout or sderr.
+type Output struct {
+	Data string `xml:",cdata"`
+}
+
+// CreateFromReport creates a JUnit representation of the given gtr.Report.
+func CreateFromReport(report gtr.Report, hostname string) Testsuites {
+	var suites Testsuites
+	for _, pkg := range report.Packages {
+		var duration time.Duration
+		suite := Testsuite{
+			Name:     pkg.Name,
+			Hostname: hostname,
+			ID:       len(suites.Suites),
+		}
+
+		if !pkg.Timestamp.IsZero() {
+			suite.SetTimestamp(pkg.Timestamp)
+		}
+
+		for _, p := range pkg.Properties {
+			suite.AddProperty(p.Name, p.Value)
+		}
+
+		if len(pkg.Output) > 0 {
+			suite.SystemOut = &Output{Data: formatOutput(pkg.Output)}
+		}
+
+		if pkg.Coverage > 0 {
+			suite.AddProperty("coverage.statements.pct", fmt.Sprintf("%.2f", pkg.Coverage))
+		}
+
+		for _, test := range pkg.Tests {
+			duration += test.Duration
+			suite.AddTestcase(createTestcaseForTest(pkg.Name, test))
+		}
+
+		// JUnit doesn't have a good way of dealing with build or runtime
+		// errors that happen before a test has started, so we create a single
+		// failing test that contains the build error details.
+		if pkg.BuildError.Name != "" {
+			tc := Testcase{
+				Classname: pkg.BuildError.Name,
+				Name:      pkg.BuildError.Cause,
+				Time:      formatDuration(0),
+				Error: &Result{
+					Message: "Build error",
+					Data:    strings.Join(pkg.BuildError.Output, "\n"),
+				},
+			}
+			suite.AddTestcase(tc)
+		}
+
+		if pkg.RunError.Name != "" {
+			tc := Testcase{
+				Classname: pkg.RunError.Name,
+				Name:      "Failure",
+				Time:      formatDuration(0),
+				Error: &Result{
+					Message: "Runtime error",
+					Data:    strings.Join(pkg.RunError.Output, "\n"),
+				},
+			}
+			suite.AddTestcase(tc)
+		}
+
+		if (pkg.Duration) == 0 {
+			suite.Time = formatDuration(duration)
+		} else {
+			suite.Time = formatDuration(pkg.Duration)
+		}
+		suites.AddSuite(suite)
+	}
+	return suites
+}
+
+func createTestcaseForTest(pkgName string, test gtr.Test) Testcase {
+	tc := Testcase{
+		Classname: pkgName,
+		Name:      test.Name,
+		Time:      formatDuration(test.Duration),
+	}
+
+	if test.Result == gtr.Fail {
+		tc.Failure = &Result{
+			Message: "Failed",
+			Data:    formatOutput(test.Output),
+		}
+	} else if test.Result == gtr.Skip {
+		tc.Skipped = &Result{
+			Message: "Skipped",
+			Data:    formatOutput(test.Output),
+		}
+	} else if test.Result == gtr.Unknown {
+		tc.Error = &Result{
+			Message: "No test result found",
+			Data:    formatOutput(test.Output),
+		}
+	} else if len(test.Output) > 0 {
+		tc.SystemOut = &Output{Data: formatOutput(test.Output)}
+	}
+	return tc
+}
+
+// formatDuration returns the JUnit string representation of the given
+// duration.
+func formatDuration(d time.Duration) string {
+	return fmt.Sprintf("%.3f", d.Seconds())
+}
+
+// formatOutput combines the lines from the given output into a single string.
+func formatOutput(output []string) string {
+	return escapeIllegalChars(strings.Join(output, "\n"))
+}
+
+func escapeIllegalChars(str string) string {
+	return strings.Map(func(r rune) rune {
+		if isInCharacterRange(r) {
+			return r
+		}
+		return '\uFFFD'
+	}, str)
+}
+
+// Decide whether the given rune is in the XML Character Range, per
+// the Char production of https://www.xml.com/axml/testaxml.htm,
+// Section 2.2 Characters.
+// From: encoding/xml/xml.go
+func isInCharacterRange(r rune) (inrange bool) {
+	return r == 0x09 ||
+		r == 0x0A ||
+		r == 0x0D ||
+		r >= 0x20 && r <= 0xD7FF ||
+		r >= 0xE000 && r <= 0xFFFD ||
+		r >= 0x10000 && r <= 0x10FFFF
+}

--- a/vendor/github.com/jstemmer/go-junit-report/v2/parser/gotest/benchmark.go
+++ b/vendor/github.com/jstemmer/go-junit-report/v2/parser/gotest/benchmark.go
@@ -1,0 +1,48 @@
+package gotest
+
+import (
+	"time"
+
+	"github.com/jstemmer/go-junit-report/v2/gtr"
+)
+
+const (
+	key = "gotest.benchmark"
+)
+
+// Benchmark contains benchmark results and is intended to be used as extra
+// data in a gtr.Test.
+type Benchmark struct {
+	Iterations  int64
+	NsPerOp     float64
+	MBPerSec    float64
+	BytesPerOp  int64
+	AllocsPerOp int64
+}
+
+// ApproximateDuration returns the duration calculated by multiplying the
+// iterations and average time per iteration (NsPerOp).
+func (b Benchmark) ApproximateDuration() time.Duration {
+	return time.Duration(float64(b.Iterations)*b.NsPerOp) * time.Nanosecond
+}
+
+// GetBenchmarkData is a helper function that returns the benchmark contained
+// in the data field of the given gtr.Test t. If no (valid) benchmark is
+// present, ok will be set to false.
+func GetBenchmarkData(t gtr.Test) (b Benchmark, ok bool) {
+	if t.Data != nil {
+		if data, exists := t.Data[key]; exists {
+			bm, ok := data.(Benchmark)
+			return bm, ok
+		}
+	}
+	return Benchmark{}, false
+}
+
+// SetBenchmarkData is a helper function that writes the benchmark b to the
+// data field of the given gtr.Test t.
+func SetBenchmarkData(t *gtr.Test, b Benchmark) {
+	if t.Data != nil {
+		t.Data[key] = b
+	}
+}

--- a/vendor/github.com/jstemmer/go-junit-report/v2/parser/gotest/event.go
+++ b/vendor/github.com/jstemmer/go-junit-report/v2/parser/gotest/event.go
@@ -1,0 +1,37 @@
+package gotest
+
+import (
+	"time"
+
+	"github.com/jstemmer/go-junit-report/v2/parser/gotest/internal/reader"
+)
+
+// Event is a single event in a Go test or benchmark.
+type Event struct {
+	Type string `json:"type"`
+
+	Name     string        `json:"name,omitempty"`
+	Package  string        `json:"pkg,omitempty"`
+	Result   string        `json:"result,omitempty"`
+	Duration time.Duration `json:"duration,omitempty"`
+	Data     string        `json:"data,omitempty"`
+	Indent   int           `json:"indent,omitempty"`
+
+	// Code coverage
+	CovPct      float64  `json:"coverage_percentage,omitempty"`
+	CovPackages []string `json:"coverage_packages,omitempty"`
+
+	// Benchmarks
+	Iterations  int64   `json:"benchmark_iterations,omitempty"`
+	NsPerOp     float64 `json:"benchmark_ns_per_op,omitempty"`
+	MBPerSec    float64 `json:"benchmark_mb_per_sec,omitempty"`
+	BytesPerOp  int64   `json:"benchmark_bytes_per_op,omitempty"`
+	AllocsPerOp int64   `json:"benchmark_allocs_per_op,omitempty"`
+}
+
+func (e *Event) applyMetadata(m *reader.Metadata) {
+	if e == nil || m == nil {
+		return
+	}
+	e.Package = m.Package
+}

--- a/vendor/github.com/jstemmer/go-junit-report/v2/parser/gotest/gotest.go
+++ b/vendor/github.com/jstemmer/go-junit-report/v2/parser/gotest/gotest.go
@@ -1,0 +1,347 @@
+// Package gotest is a standard Go test output parser.
+package gotest
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/jstemmer/go-junit-report/v2/gtr"
+	"github.com/jstemmer/go-junit-report/v2/parser/gotest/internal/reader"
+)
+
+const (
+	// maxLineSize is the maximum amount of bytes we'll read for a single line.
+	// Lines longer than maxLineSize will be truncated.
+	maxLineSize = 4 * 1024 * 1024
+)
+
+var (
+	// regexBenchInfo captures 3-5 groups: benchmark name, number of times ran, ns/op (with or without decimal), MB/sec (optional), B/op (optional), and allocs/op (optional).
+	regexBenchmark    = regexp.MustCompile(`^(Benchmark[^ -]+)$`)
+	regexBenchSummary = regexp.MustCompile(`^(Benchmark[^ -]+)(?:-\d+\s+|\s+)(\d+)\s+(\d+|\d+\.\d+)\sns\/op(?:\s+(\d+|\d+\.\d+)\sMB\/s)?(?:\s+(\d+)\sB\/op)?(?:\s+(\d+)\sallocs/op)?`)
+	regexCoverage     = regexp.MustCompile(`^coverage:\s+(\d+|\d+\.\d+)%\s+of\s+statements(?:\sin\s(.+))?$`)
+	regexEndBenchmark = regexp.MustCompile(`^--- (BENCH|FAIL|SKIP): (Benchmark[^ -]+)(?:-\d+)?$`)
+	regexEndTest      = regexp.MustCompile(`((?:    )*)--- (PASS|FAIL|SKIP): ([^ ]+) \((\d+\.\d+)(?: seconds|s)\)`)
+	regexStatus       = regexp.MustCompile(`^(PASS|FAIL|SKIP)$`)
+	regexSummary      = regexp.MustCompile(`` +
+		// 1: result
+		`^(\?|ok|FAIL)` +
+		// 2: package name
+		`\s+([^ \t]+)` +
+		// 3: duration (optional)
+		`(?:\s+(\d+\.\d+)s)?` +
+		// 4: cached indicator (optional)
+		`(?:\s+(\(cached\)))?` +
+		// 5: coverage percentage (optional)
+		// 6: coverage package list (optional)
+		`(?:\s+coverage:\s+(?:\[no\sstatements\]|(\d+\.\d+)%\sof\sstatements(?:\sin\s(.+))?))?` +
+		// 7: [status message] (optional)
+		`(?:\s+(\[[^\]]+\]))?` +
+		`$`)
+)
+
+// Option defines options that can be passed to gotest.New.
+type Option func(*Parser)
+
+// PackageName is an Option that sets the default package name to use when it
+// cannot be determined from the test output.
+func PackageName(name string) Option {
+	return func(p *Parser) {
+		p.packageName = name
+	}
+}
+
+// TimestampFunc is an Option that sets the timestamp function that is used to
+// determine the current time when creating the Report. This can be used to
+// override the default behaviour of using time.Now().
+func TimestampFunc(f func() time.Time) Option {
+	return func(p *Parser) {
+		p.timestampFunc = f
+	}
+}
+
+// SubtestMode configures how Go subtests should be handled by the parser.
+type SubtestMode string
+
+const (
+	// SubtestModeDefault is the default subtest mode. It treats tests with
+	// subtests as any other tests.
+	SubtestModeDefault SubtestMode = ""
+
+	// IgnoreParentResults ignores test results for tests with subtests. Use
+	// this mode if you use subtest parents for common setup/teardown, but are
+	// not interested in counting them as failed tests. Ignoring their results
+	// still preserves these tests and their captured output in the report.
+	IgnoreParentResults SubtestMode = "ignore-parent-results"
+
+	// ExcludeParents excludes tests that contain subtests from the report.
+	// Note that the subtests themselves are not removed. Use this mode if you
+	// use subtest parents for common setup/teardown, but are not actually
+	// interested in their presence in the created report. If output was
+	// captured for tests that are removed, the output is preserved in the
+	// global report output.
+	ExcludeParents SubtestMode = "exclude-parents"
+)
+
+// ParseSubtestMode returns a SubtestMode for the given string.
+func ParseSubtestMode(in string) (SubtestMode, error) {
+	switch in {
+	case string(IgnoreParentResults):
+		return IgnoreParentResults, nil
+	case string(ExcludeParents):
+		return ExcludeParents, nil
+	default:
+		return SubtestModeDefault, fmt.Errorf("unknown subtest mode: %v", in)
+	}
+}
+
+// SetSubtestMode is an Option to change how the parser handles tests with
+// subtests. See the documentation for the individual SubtestModes for more
+// information.
+func SetSubtestMode(mode SubtestMode) Option {
+	return func(p *Parser) {
+		p.subtestMode = mode
+	}
+}
+
+// Parser is a Go test output Parser.
+type Parser struct {
+	packageName string
+	subtestMode SubtestMode
+
+	timestampFunc func() time.Time
+
+	events []Event
+}
+
+// NewParser returns a new Go test output parser.
+func NewParser(options ...Option) *Parser {
+	p := &Parser{}
+	for _, option := range options {
+		option(p)
+	}
+	return p
+}
+
+// Parse parses Go test output from the given io.Reader r and returns
+// gtr.Report.
+func (p *Parser) Parse(r io.Reader) (gtr.Report, error) {
+	return p.parse(reader.NewLimitedLineReader(r, maxLineSize))
+}
+
+func (p *Parser) parse(r reader.LineReader) (gtr.Report, error) {
+	p.events = nil
+
+	rb := newReportBuilder()
+	rb.packageName = p.packageName
+	rb.subtestMode = p.subtestMode
+	if p.timestampFunc != nil {
+		rb.timestampFunc = p.timestampFunc
+	}
+
+	for {
+		line, metadata, err := r.ReadLine()
+		if err == io.EOF {
+			break
+		} else if err != nil {
+			return gtr.Report{}, err
+		}
+
+		var evs []Event
+
+		// Lines that exceed bufio.MaxScanTokenSize are not expected to contain
+		// any relevant test infrastructure output, so instead of parsing them
+		// we treat them as regular output to increase performance.
+		//
+		// Parser used a bufio.Scanner in the past, which only supported
+		// reading lines up to bufio.MaxScanTokenSize in length. Since this
+		// turned out to be fine in almost all cases, it seemed an appropriate
+		// value to use to decide whether or not to attempt parsing this line.
+		if len(line) > bufio.MaxScanTokenSize {
+			evs = p.output(line)
+		} else {
+			evs = p.parseLine(line)
+		}
+
+		for _, ev := range evs {
+			ev.applyMetadata(metadata)
+			rb.ProcessEvent(ev)
+			p.events = append(p.events, ev)
+		}
+	}
+	return rb.Build(), nil
+}
+
+// Events returns the events created by the parser.
+func (p *Parser) Events() []Event {
+	events := make([]Event, len(p.events))
+	copy(events, p.events)
+	return events
+}
+
+func (p *Parser) parseLine(line string) (events []Event) {
+	if strings.HasPrefix(line, "=== RUN ") {
+		return p.runTest(strings.TrimSpace(line[8:]))
+	} else if strings.HasPrefix(line, "=== PAUSE ") {
+		return p.pauseTest(strings.TrimSpace(line[10:]))
+	} else if strings.HasPrefix(line, "=== CONT ") {
+		return p.contTest(strings.TrimSpace(line[9:]))
+	} else if strings.HasPrefix(line, "=== NAME ") {
+		// for compatibility with gotest 1.20+ https://go-review.git.corp.google.com/c/go/+/443596
+		return p.contTest(strings.TrimSpace(line[9:]))
+	} else if matches := regexEndTest.FindStringSubmatch(line); len(matches) == 5 {
+		return p.endTest(line, matches[1], matches[2], matches[3], matches[4])
+	} else if matches := regexStatus.FindStringSubmatch(line); len(matches) == 2 {
+		return p.status(matches[1])
+	} else if matches := regexSummary.FindStringSubmatch(line); len(matches) == 8 {
+		return p.summary(matches[1], matches[2], matches[3], matches[4], matches[7], matches[5], matches[6])
+	} else if matches := regexCoverage.FindStringSubmatch(line); len(matches) == 3 {
+		return p.coverage(matches[1], matches[2])
+	} else if matches := regexBenchmark.FindStringSubmatch(line); len(matches) == 2 {
+		return p.runBench(matches[1])
+	} else if matches := regexBenchSummary.FindStringSubmatch(line); len(matches) == 7 {
+		return p.benchSummary(matches[1], matches[2], matches[3], matches[4], matches[5], matches[6])
+	} else if matches := regexEndBenchmark.FindStringSubmatch(line); len(matches) == 3 {
+		return p.endBench(matches[1], matches[2])
+	} else if strings.HasPrefix(line, "# ") {
+		fields := strings.Fields(strings.TrimPrefix(line, "# "))
+		if len(fields) == 1 || len(fields) == 2 {
+			return p.buildOutput(fields[0])
+		}
+	}
+	return p.output(line)
+}
+
+func (p *Parser) runTest(name string) []Event {
+	return []Event{{Type: "run_test", Name: name}}
+}
+
+func (p *Parser) pauseTest(name string) []Event {
+	return []Event{{Type: "pause_test", Name: name}}
+}
+
+func (p *Parser) contTest(name string) []Event {
+	return []Event{{Type: "cont_test", Name: name}}
+}
+
+func (p *Parser) endTest(line, indent, result, name, duration string) []Event {
+	var events []Event
+	if idx := strings.Index(line, fmt.Sprintf("%s--- %s:", indent, result)); idx > 0 {
+		events = append(events, p.output(line[:idx])...)
+	}
+	_, n := stripIndent(indent)
+	events = append(events, Event{
+		Type:     "end_test",
+		Name:     name,
+		Result:   result,
+		Indent:   n,
+		Duration: parseSeconds(duration),
+	})
+	return events
+}
+
+func (p *Parser) status(result string) []Event {
+	return []Event{{Type: "status", Result: result}}
+}
+
+func (p *Parser) summary(result, name, duration, cached, status, covpct, packages string) []Event {
+	return []Event{{
+		Type:        "summary",
+		Result:      result,
+		Name:        name,
+		Duration:    parseSeconds(duration),
+		Data:        strings.TrimSpace(cached + " " + status),
+		CovPct:      parseFloat(covpct),
+		CovPackages: parsePackages(packages),
+	}}
+}
+
+func (p *Parser) coverage(percent, packages string) []Event {
+	return []Event{{
+		Type:        "coverage",
+		CovPct:      parseFloat(percent),
+		CovPackages: parsePackages(packages),
+	}}
+}
+
+func (p *Parser) runBench(name string) []Event {
+	return []Event{{
+		Type: "run_benchmark",
+		Name: name,
+	}}
+}
+
+func (p *Parser) benchSummary(name, iterations, nsPerOp, mbPerSec, bytesPerOp, allocsPerOp string) []Event {
+	return []Event{{
+		Type:        "benchmark",
+		Name:        name,
+		Iterations:  parseInt(iterations),
+		NsPerOp:     parseFloat(nsPerOp),
+		MBPerSec:    parseFloat(mbPerSec),
+		BytesPerOp:  parseInt(bytesPerOp),
+		AllocsPerOp: parseInt(allocsPerOp),
+	}}
+}
+
+func (p *Parser) endBench(result, name string) []Event {
+	return []Event{{
+		Type:   "end_benchmark",
+		Name:   name,
+		Result: result,
+	}}
+}
+
+func (p *Parser) buildOutput(packageName string) []Event {
+	return []Event{{
+		Type: "build_output",
+		Name: packageName,
+	}}
+}
+
+func (p *Parser) output(line string) []Event {
+	return []Event{{Type: "output", Data: line}}
+}
+
+func parseSeconds(s string) time.Duration {
+	if s == "" {
+		return time.Duration(0)
+	}
+	// ignore error
+	d, _ := time.ParseDuration(s + "s")
+	return d
+}
+
+func parseFloat(s string) float64 {
+	if s == "" {
+		return 0
+	}
+	// ignore error
+	pct, _ := strconv.ParseFloat(s, 64)
+	return pct
+}
+
+func parsePackages(pkgList string) []string {
+	if len(pkgList) == 0 {
+		return nil
+	}
+	return strings.Split(pkgList, ", ")
+}
+
+func parseInt(s string) int64 {
+	// ignore error
+	n, _ := strconv.ParseInt(s, 10, 64)
+	return n
+}
+
+func stripIndent(line string) (string, int) {
+	var indent int
+	for indent = 0; strings.HasPrefix(line, "    "); indent++ {
+		line = line[4:]
+	}
+	return line, indent
+}

--- a/vendor/github.com/jstemmer/go-junit-report/v2/parser/gotest/internal/collector/collector.go
+++ b/vendor/github.com/jstemmer/go-junit-report/v2/parser/gotest/internal/collector/collector.go
@@ -1,0 +1,97 @@
+// Package collector collects output lines grouped by id and provides ways to
+// retrieve and merge output ordered by the time each line was added.
+package collector
+
+import (
+	"sort"
+	"time"
+)
+
+// line is a single line of output captured at some point in time.
+type line struct {
+	Timestamp time.Time
+	Text      string
+}
+
+// Output stores output lines grouped by id. Output can be retrieved for one or
+// more ids and output for different ids can be merged together, while
+// preserving their insertion original order based on the time it was
+// collected.
+// Output also tracks the active id, so you can append output without providing
+// an id.
+type Output struct {
+	m  map[int][]line
+	id int // active id
+}
+
+// New returns a new output collector.
+func New() *Output {
+	return &Output{m: make(map[int][]line)}
+}
+
+// Clear deletes all output for the given id.
+func (o *Output) Clear(id int) {
+	delete(o.m, id)
+}
+
+// Append appends the given line of text to the output of the currently active
+// id.
+func (o *Output) Append(text string) {
+	o.m[o.id] = append(o.m[o.id], line{time.Now(), text})
+}
+
+// AppendToID appends the given line of text to the output of the given id.
+func (o *Output) AppendToID(id int, text string) {
+	o.m[id] = append(o.m[id], line{time.Now(), text})
+}
+
+// Contains returns true if any output lines were collected for the given id.
+func (o *Output) Contains(id int) bool {
+	return len(o.m[id]) > 0
+}
+
+// Get returns the output lines for the given id.
+func (o *Output) Get(id int) []string {
+	var lines []string
+	for _, line := range o.m[id] {
+		lines = append(lines, line.Text)
+	}
+	return lines
+}
+
+// GetAll returns the output lines for all ids sorted by the collection
+// timestamp of each line of output.
+func (o *Output) GetAll(ids ...int) []string {
+	var output []line
+	for _, id := range ids {
+		output = append(output, o.m[id]...)
+	}
+	sort.Slice(output, func(i, j int) bool {
+		return output[i].Timestamp.Before(output[j].Timestamp)
+	})
+	var lines []string
+	for _, line := range output {
+		lines = append(lines, line.Text)
+	}
+	return lines
+}
+
+// Merge merges the output lines from fromID into intoID, and sorts the output
+// by the collection timestamp of each line of output.
+func (o *Output) Merge(fromID, intoID int) {
+	var merged []line
+	for _, id := range []int{fromID, intoID} {
+		merged = append(merged, o.m[id]...)
+	}
+	sort.Slice(merged, func(i, j int) bool {
+		return merged[i].Timestamp.Before(merged[j].Timestamp)
+	})
+	o.m[intoID] = merged
+	delete(o.m, fromID)
+}
+
+// SetActiveID sets the active id. Text appended to this output will be
+// associated with the active id.
+func (o *Output) SetActiveID(id int) {
+	o.id = id
+}

--- a/vendor/github.com/jstemmer/go-junit-report/v2/parser/gotest/internal/reader/reader.go
+++ b/vendor/github.com/jstemmer/go-junit-report/v2/parser/gotest/internal/reader/reader.go
@@ -1,0 +1,122 @@
+package reader
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"io"
+	"strings"
+	"time"
+)
+
+// LineReader is an interface to read lines with optional Metadata.
+type LineReader interface {
+	ReadLine() (string, *Metadata, error)
+}
+
+// Metadata contains metadata that belongs to a line.
+type Metadata struct {
+	Package string
+}
+
+// LimitedLineReader reads lines from an io.Reader object with a configurable
+// line size limit. Lines exceeding the limit will be truncated, but read
+// completely from the underlying io.Reader.
+type LimitedLineReader struct {
+	r     *bufio.Reader
+	limit int
+}
+
+var _ LineReader = &LimitedLineReader{}
+
+// NewLimitedLineReader returns a LimitedLineReader to read lines from r with a
+// maximum line size of limit.
+func NewLimitedLineReader(r io.Reader, limit int) *LimitedLineReader {
+	return &LimitedLineReader{r: bufio.NewReader(r), limit: limit}
+}
+
+// ReadLine returns the next line from the underlying reader. The length of the
+// line will not exceed the configured limit. ReadLine either returns a line or
+// it returns an error, never both.
+func (r *LimitedLineReader) ReadLine() (string, *Metadata, error) {
+	line, isPrefix, err := r.r.ReadLine()
+	if err != nil {
+		return "", nil, err
+	}
+
+	if !isPrefix {
+		return string(line), nil, nil
+	}
+
+	// Line is incomplete, keep reading until we reach the end of the line.
+	var buf bytes.Buffer
+	buf.Write(line) // ignore err, always nil
+	for isPrefix {
+		line, isPrefix, err = r.r.ReadLine()
+		if err != nil {
+			return "", nil, err
+		}
+
+		if buf.Len() >= r.limit {
+			// Stop writing to buf if we exceed the limit. We continue reading
+			// however to make sure we consume the entire line.
+			continue
+		}
+
+		buf.Write(line) // ignore err, always nil
+	}
+
+	if buf.Len() > r.limit {
+		buf.Truncate(r.limit)
+	}
+	return buf.String(), nil, nil
+}
+
+// Event represents a JSON event emitted by `go test -json`.
+type Event struct {
+	Time    time.Time
+	Action  string
+	Package string
+	Test    string
+	Elapsed float64 // seconds
+	Output  string
+}
+
+// JSONEventReader reads JSON events from an io.Reader object.
+type JSONEventReader struct {
+	r *LimitedLineReader
+}
+
+var _ LineReader = &JSONEventReader{}
+
+// jsonLineLimit is the maximum size of a single JSON line emitted by `go test
+// -json`.
+const jsonLineLimit = 64 * 1024
+
+// NewJSONEventReader returns a JSONEventReader to read the data in JSON
+// events from r.
+func NewJSONEventReader(r io.Reader) *JSONEventReader {
+	return &JSONEventReader{NewLimitedLineReader(r, jsonLineLimit)}
+}
+
+// ReadLine returns the next line from the underlying reader.
+func (r *JSONEventReader) ReadLine() (string, *Metadata, error) {
+	for {
+		line, _, err := r.r.ReadLine()
+		if err != nil {
+			return "", nil, err
+		}
+		if len(line) == 0 || line[0] != '{' {
+			return line, nil, nil
+		}
+		event := &Event{}
+		if err := json.Unmarshal([]byte(line), event); err != nil {
+			return "", nil, err
+		}
+		if event.Output == "" {
+			// Skip events without output
+			continue
+		}
+		return strings.TrimSuffix(event.Output, "\n"), &Metadata{Package: event.Package}, nil
+	}
+}

--- a/vendor/github.com/jstemmer/go-junit-report/v2/parser/gotest/json.go
+++ b/vendor/github.com/jstemmer/go-junit-report/v2/parser/gotest/json.go
@@ -1,0 +1,29 @@
+package gotest
+
+import (
+	"io"
+
+	"github.com/jstemmer/go-junit-report/v2/gtr"
+	"github.com/jstemmer/go-junit-report/v2/parser/gotest/internal/reader"
+)
+
+// NewJSONParser returns a new Go test json output parser.
+func NewJSONParser(options ...Option) *JSONParser {
+	return &JSONParser{gp: NewParser(options...)}
+}
+
+// JSONParser is a `go test -json` output Parser.
+type JSONParser struct {
+	gp *Parser
+}
+
+// Parse parses Go test json output from the given io.Reader r and returns
+// gtr.Report.
+func (p *JSONParser) Parse(r io.Reader) (gtr.Report, error) {
+	return p.gp.parse(reader.NewJSONEventReader(r))
+}
+
+// Events returns the events created by the parser.
+func (p *JSONParser) Events() []Event {
+	return p.gp.Events()
+}

--- a/vendor/github.com/jstemmer/go-junit-report/v2/parser/gotest/report_builder.go
+++ b/vendor/github.com/jstemmer/go-junit-report/v2/parser/gotest/report_builder.go
@@ -1,0 +1,499 @@
+package gotest
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/jstemmer/go-junit-report/v2/gtr"
+	"github.com/jstemmer/go-junit-report/v2/parser/gotest/internal/collector"
+)
+
+const (
+	globalID = 0
+)
+
+// reportBuilder helps build a test Report from a collection of events.
+//
+// The reportBuilder delegates to the packageBuilder for creating packages from
+// basic test events, but keeps track of build errors itself. The reportBuilder
+// is also responsible for generating unique test id's.
+//
+// Test output is collected by the output collector, which also keeps track of
+// the currently active test so output is automatically associated with the
+// correct test.
+type reportBuilder struct {
+	packageBuilders map[string]*packageBuilder
+	buildErrors     map[int]gtr.Error
+
+	nextID   int               // next free unused id
+	output   *collector.Output // output collected for each id
+	packages []gtr.Package     // completed packages
+
+	// options
+	packageName   string
+	subtestMode   SubtestMode
+	timestampFunc func() time.Time
+}
+
+// newReportBuilder creates a new reportBuilder.
+func newReportBuilder() *reportBuilder {
+	return &reportBuilder{
+		packageBuilders: make(map[string]*packageBuilder),
+		buildErrors:     make(map[int]gtr.Error),
+		nextID:          1,
+		output:          collector.New(),
+		timestampFunc:   time.Now,
+	}
+}
+
+// getPackageBuilder returns the packageBuilder for the given packageName. If
+// no packageBuilder exists for the given package, a new one is created.
+func (b *reportBuilder) getPackageBuilder(packageName string) *packageBuilder {
+	pb, ok := b.packageBuilders[packageName]
+	if !ok {
+		output := b.output
+		if packageName != "" {
+			output = collector.New()
+		}
+		pb = newPackageBuilder(b.generateID, output)
+		b.packageBuilders[packageName] = pb
+	}
+	return pb
+}
+
+// ProcessEvent takes a test event and adds it to the report.
+func (b *reportBuilder) ProcessEvent(ev Event) {
+	switch ev.Type {
+	case "run_test":
+		b.getPackageBuilder(ev.Package).CreateTest(ev.Name)
+	case "pause_test":
+		b.getPackageBuilder(ev.Package).PauseTest(ev.Name)
+	case "cont_test":
+		b.getPackageBuilder(ev.Package).ContinueTest(ev.Name)
+	case "end_test":
+		b.getPackageBuilder(ev.Package).EndTest(ev.Name, ev.Result, ev.Duration, ev.Indent)
+	case "run_benchmark":
+		b.getPackageBuilder(ev.Package).CreateTest(ev.Name)
+	case "benchmark":
+		b.getPackageBuilder(ev.Package).BenchmarkResult(ev.Name, ev.Iterations, ev.NsPerOp, ev.MBPerSec, ev.BytesPerOp, ev.AllocsPerOp)
+	case "end_benchmark":
+		b.getPackageBuilder(ev.Package).EndTest(ev.Name, ev.Result, 0, 0)
+	case "status":
+		b.getPackageBuilder(ev.Package).End()
+	case "summary":
+		// The summary marks the end of a package. We can now create the actual
+		// package from all the events we've processed so far for this package.
+		b.packages = append(b.packages, b.CreatePackage(ev.Package, ev.Name, ev.Result, ev.Duration, ev.Data))
+	case "coverage":
+		b.getPackageBuilder(ev.Package).Coverage(ev.CovPct, ev.CovPackages)
+	case "build_output":
+		b.CreateBuildError(ev.Name)
+	case "output":
+		if ev.Package != "" {
+			b.getPackageBuilder(ev.Package).Output(ev.Data)
+		} else {
+			b.output.Append(ev.Data)
+		}
+	default:
+		// This shouldn't happen, but just in case print a warning and ignore
+		// this event.
+		fmt.Printf("reportBuilder: unhandled event type: %v\n", ev.Type)
+	}
+}
+
+// newID returns a new unique id.
+func (b *reportBuilder) generateID() int {
+	id := b.nextID
+	b.nextID++
+	return id
+}
+
+// Build returns the new Report containing all the tests, build errors and
+// their output created from the processed events.
+func (b *reportBuilder) Build() gtr.Report {
+	// Create packages for any leftover package builders.
+	for name, pb := range b.packageBuilders {
+		if pb.IsEmpty() {
+			continue
+		}
+		b.packages = append(b.packages, b.CreatePackage(name, b.packageName, "", 0, ""))
+	}
+
+	// Create packages for any leftover build errors.
+	for _, buildErr := range b.buildErrors {
+		b.packages = append(b.packages, b.CreatePackage("", buildErr.Name, "", 0, ""))
+	}
+	return gtr.Report{Packages: b.packages}
+}
+
+// CreateBuildError creates a new build error and marks it as active.
+func (b *reportBuilder) CreateBuildError(packageName string) {
+	id := b.generateID()
+	b.output.SetActiveID(id)
+	b.buildErrors[id] = gtr.Error{ID: id, Name: packageName}
+}
+
+// CreatePackage returns a new package containing all the build errors, output,
+// tests and benchmarks created so far. The optional packageName is used to
+// find the correct reportBuilder. The newPackageName is the actual package
+// name that will be given to the returned package, which should be used in
+// case the packageName was unknown until this point.
+func (b *reportBuilder) CreatePackage(packageName, newPackageName, result string, duration time.Duration, data string) gtr.Package {
+	pkg := gtr.Package{
+		Name:      newPackageName,
+		Duration:  duration,
+		Timestamp: b.timestampFunc(),
+	}
+
+	// First check if this package contained a build error. If that's the case,
+	// we won't find any tests in this package.
+	for id, buildErr := range b.buildErrors {
+		if buildErr.Name == newPackageName || strings.TrimSuffix(buildErr.Name, "_test") == newPackageName {
+			pkg.BuildError = buildErr
+			pkg.BuildError.ID = id
+			pkg.BuildError.Duration = duration
+			pkg.BuildError.Cause = data
+			pkg.BuildError.Output = b.output.Get(id)
+
+			delete(b.buildErrors, id)
+			b.output.SetActiveID(0)
+			return pkg
+		}
+	}
+
+	// Get the packageBuilder for this package and make sure it's deleted, so
+	// future events for this package will use a new packageBuilder.
+	pb := b.getPackageBuilder(packageName)
+	delete(b.packageBuilders, packageName)
+	pb.output.SetActiveID(0)
+
+	// If the packageBuilder is empty, we never received any events for this
+	// package so there's no need to continue.
+	if pb.IsEmpty() {
+		// However, we should at least report an error if the result says we
+		// failed.
+		if parseResult(result) == gtr.Fail {
+			pkg.RunError = gtr.Error{
+				Name: newPackageName,
+			}
+		}
+		return pkg
+	}
+
+	// If we've collected output, but there were no tests, then this package
+	// had a runtime error or it simply didn't have any tests.
+	if pb.output.Contains(globalID) && len(pb.tests) == 0 {
+		if parseResult(result) == gtr.Fail {
+			pkg.RunError = gtr.Error{
+				Name:   newPackageName,
+				Output: pb.output.Get(globalID),
+			}
+		} else {
+			pkg.Output = pb.output.Get(globalID)
+		}
+		pb.output.Clear(globalID)
+		return pkg
+	}
+
+	// If the summary result says we failed, but there were no failing tests
+	// then something else must have failed.
+	if parseResult(result) == gtr.Fail && len(pb.tests) > 0 && !pb.containsFailures() {
+		pkg.RunError = gtr.Error{
+			Name:   newPackageName,
+			Output: pb.output.Get(globalID),
+		}
+		pb.output.Clear(globalID)
+	}
+
+	// Collect tests for this package
+	var tests []gtr.Test
+	for id, t := range pb.tests {
+		if pb.isParent(id) {
+			if b.subtestMode == IgnoreParentResults {
+				t.Result = gtr.Pass
+			} else if b.subtestMode == ExcludeParents {
+				pb.output.Merge(id, globalID)
+				continue
+			}
+		}
+		t.Output = pb.output.Get(id)
+		tests = append(tests, t)
+	}
+	tests = groupBenchmarksByName(tests, b.output)
+
+	// Sort packages by id to ensure we maintain insertion order.
+	sort.Slice(tests, func(i, j int) bool {
+		return tests[i].ID < tests[j].ID
+	})
+
+	pkg.Tests = groupBenchmarksByName(tests, pb.output)
+	pkg.Coverage = pb.coverage
+	pkg.Output = pb.output.Get(globalID)
+	pb.output.Clear(globalID)
+	return pkg
+}
+
+// parseResult returns a gtr.Result for the given result string r.
+func parseResult(r string) gtr.Result {
+	switch r {
+	case "PASS":
+		return gtr.Pass
+	case "FAIL":
+		return gtr.Fail
+	case "SKIP":
+		return gtr.Skip
+	case "BENCH":
+		return gtr.Pass
+	default:
+		return gtr.Unknown
+	}
+}
+
+// groupBenchmarksByName groups tests with the Benchmark prefix if they have
+// the same name and combines their output.
+func groupBenchmarksByName(tests []gtr.Test, output *collector.Output) []gtr.Test {
+	if len(tests) == 0 {
+		return nil
+	}
+
+	var grouped []gtr.Test
+	byName := make(map[string][]gtr.Test)
+	for _, test := range tests {
+		if !strings.HasPrefix(test.Name, "Benchmark") {
+			// If this test is not a benchmark, we won't group it by name but
+			// just add it to the final result.
+			grouped = append(grouped, test)
+			continue
+		}
+		if _, ok := byName[test.Name]; !ok {
+			grouped = append(grouped, gtr.NewTest(test.ID, test.Name))
+		}
+		byName[test.Name] = append(byName[test.Name], test)
+	}
+
+	for i, group := range grouped {
+		if !strings.HasPrefix(group.Name, "Benchmark") {
+			continue
+		}
+		var (
+			ids   []int
+			total Benchmark
+			count int
+		)
+		for _, test := range byName[group.Name] {
+			ids = append(ids, test.ID)
+			if test.Result != gtr.Pass {
+				continue
+			}
+
+			if bench, ok := GetBenchmarkData(test); ok {
+				total.Iterations += bench.Iterations
+				total.NsPerOp += bench.NsPerOp
+				total.MBPerSec += bench.MBPerSec
+				total.BytesPerOp += bench.BytesPerOp
+				total.AllocsPerOp += bench.AllocsPerOp
+				count++
+			}
+		}
+
+		group.Duration = combinedDuration(byName[group.Name])
+		group.Result = groupResults(byName[group.Name])
+		group.Output = output.GetAll(ids...)
+		if count > 0 {
+			total.Iterations /= int64(count)
+			total.NsPerOp /= float64(count)
+			total.MBPerSec /= float64(count)
+			total.BytesPerOp /= int64(count)
+			total.AllocsPerOp /= int64(count)
+			SetBenchmarkData(&group, total)
+		}
+		grouped[i] = group
+	}
+	return grouped
+}
+
+// combinedDuration returns the sum of the durations of the given tests.
+func combinedDuration(tests []gtr.Test) time.Duration {
+	var total time.Duration
+	for _, test := range tests {
+		total += test.Duration
+	}
+	return total
+}
+
+// groupResults returns the result we should use for a collection of tests.
+func groupResults(tests []gtr.Test) gtr.Result {
+	var result gtr.Result
+	for _, test := range tests {
+		if test.Result == gtr.Fail {
+			return gtr.Fail
+		}
+		if result != gtr.Pass {
+			result = test.Result
+		}
+	}
+	return result
+}
+
+// packageBuilder helps build a gtr.Package from a collection of test events.
+type packageBuilder struct {
+	generateID func() int
+	output     *collector.Output
+
+	tests     map[int]gtr.Test
+	parentIDs map[int]struct{} // set of test id's that contain subtests
+	coverage  float64          // coverage percentage
+}
+
+// newPackageBuilder creates a new packageBuilder. New tests will be assigned
+// an ID returned by the generateID function. The activeIDSetter is called to
+// set or reset the active test id.
+func newPackageBuilder(generateID func() int, output *collector.Output) *packageBuilder {
+	return &packageBuilder{
+		generateID: generateID,
+		output:     output,
+		tests:      make(map[int]gtr.Test),
+		parentIDs:  make(map[int]struct{}),
+	}
+}
+
+// IsEmpty returns true if this package builder does not have any tests and has
+// not collected any global output.
+func (b packageBuilder) IsEmpty() bool {
+	return len(b.tests) == 0 && !b.output.Contains(0)
+}
+
+// CreateTest adds a test with the given name to the package, marks it as
+// active and returns its generated id.
+func (b *packageBuilder) CreateTest(name string) int {
+	if parentID, ok := b.findTestParentID(name); ok {
+		b.parentIDs[parentID] = struct{}{}
+	}
+	id := b.generateID()
+	b.output.SetActiveID(id)
+	b.tests[id] = gtr.NewTest(id, name)
+	return id
+}
+
+// PauseTest marks the test with the given name no longer active. Any results
+// or output added to the package after calling PauseTest will no longer be
+// associated with this test.
+func (b *packageBuilder) PauseTest(name string) {
+	b.output.SetActiveID(0)
+}
+
+// ContinueTest finds the test with the given name and marks it as active. If
+// more than one test exist with this name, the most recently created test will
+// be used.
+func (b *packageBuilder) ContinueTest(name string) {
+	id, _ := b.findTest(name)
+	b.output.SetActiveID(id)
+}
+
+// EndTest finds the test with the given name, sets the result, duration and
+// level. If more than one test exists with this name, the most recently
+// created test will be used. If no test exists with this name, a new test is
+// created. The test is then marked as no longer active.
+func (b *packageBuilder) EndTest(name, result string, duration time.Duration, level int) {
+	id, ok := b.findTest(name)
+	if !ok {
+		// test did not exist, create one
+		// TODO: Likely reason is that the user ran go test without the -v
+		// flag, should we report this somewhere?
+		id = b.CreateTest(name)
+	}
+
+	t := b.tests[id]
+	t.Result = parseResult(result)
+	t.Duration = duration
+	t.Level = level
+	b.tests[id] = t
+	b.output.SetActiveID(0)
+}
+
+// End resets the active test.
+func (b *packageBuilder) End() {
+	b.output.SetActiveID(0)
+}
+
+// BenchmarkResult updates an existing or adds a new test with the given
+// results and marks it as active. If an existing test with this name exists
+// but without result, then that one is updated. Otherwise a new one is added
+// to the report.
+func (b *packageBuilder) BenchmarkResult(name string, iterations int64, nsPerOp, mbPerSec float64, bytesPerOp, allocsPerOp int64) {
+	id, ok := b.findTest(name)
+	if !ok || b.tests[id].Result != gtr.Unknown {
+		id = b.CreateTest(name)
+	}
+	b.output.SetActiveID(id)
+
+	benchmark := Benchmark{iterations, nsPerOp, mbPerSec, bytesPerOp, allocsPerOp}
+	test := gtr.NewTest(id, name)
+	test.Result = gtr.Pass
+	test.Duration = benchmark.ApproximateDuration()
+	SetBenchmarkData(&test, benchmark)
+	b.tests[id] = test
+}
+
+// Coverage sets the code coverage percentage.
+func (b *packageBuilder) Coverage(pct float64, packages []string) {
+	b.coverage = pct
+}
+
+// Output appends data to the output of this package.
+func (b *packageBuilder) Output(data string) {
+	b.output.Append(data)
+}
+
+// findTest returns the id of the most recently created test with the given
+// name if it exists.
+func (b *packageBuilder) findTest(name string) (int, bool) {
+	var maxid int
+	for id, test := range b.tests {
+		if maxid < id && test.Name == name {
+			maxid = id
+		}
+	}
+	return maxid, maxid > 0
+}
+
+// findTestParentID searches the existing tests in this package for a parent of
+// the test with the given name, and returns its id if one is found.
+func (b *packageBuilder) findTestParentID(name string) (int, bool) {
+	parent := dropLastSegment(name)
+	for parent != "" {
+		if id, ok := b.findTest(parent); ok {
+			return id, true
+		}
+		parent = dropLastSegment(parent)
+	}
+	return 0, false
+}
+
+// isParent returns true if the test with the given id has sub tests.
+func (b *packageBuilder) isParent(id int) bool {
+	_, ok := b.parentIDs[id]
+	return ok
+}
+
+// dropLastSegment strips the last `/` and everything following it from the
+// given name. If no `/` was found, the empty string is returned.
+func dropLastSegment(name string) string {
+	if idx := strings.LastIndexByte(name, '/'); idx >= 0 {
+		return name[:idx]
+	}
+	return ""
+}
+
+// containsFailures return true if this package contains at least one failing
+// test or a test with an unknown result.
+func (b *packageBuilder) containsFailures() bool {
+	for _, test := range b.tests {
+		if test.Result == gtr.Fail || test.Result == gtr.Unknown {
+			return true
+		}
+	}
+	return false
+}

--- a/vendor/github.com/kballard/go-shellquote/LICENSE
+++ b/vendor/github.com/kballard/go-shellquote/LICENSE
@@ -1,0 +1,19 @@
+Copyright (C) 2014 Kevin Ballard
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE
+OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/vendor/github.com/kballard/go-shellquote/README
+++ b/vendor/github.com/kballard/go-shellquote/README
@@ -1,0 +1,36 @@
+PACKAGE
+
+package shellquote
+    import "github.com/kballard/go-shellquote"
+
+    Shellquote provides utilities for joining/splitting strings using sh's
+    word-splitting rules.
+
+VARIABLES
+
+var (
+    UnterminatedSingleQuoteError = errors.New("Unterminated single-quoted string")
+    UnterminatedDoubleQuoteError = errors.New("Unterminated double-quoted string")
+    UnterminatedEscapeError      = errors.New("Unterminated backslash-escape")
+)
+
+
+FUNCTIONS
+
+func Join(args ...string) string
+    Join quotes each argument and joins them with a space. If passed to
+    /bin/sh, the resulting string will be split back into the original
+    arguments.
+
+func Split(input string) (words []string, err error)
+    Split splits a string according to /bin/sh's word-splitting rules. It
+    supports backslash-escapes, single-quotes, and double-quotes. Notably it
+    does not support the $'' style of quoting. It also doesn't attempt to
+    perform any other sort of expansion, including brace expansion, shell
+    expansion, or pathname expansion.
+
+    If the given input has an unterminated quoted string or ends in a
+    backslash-escape, one of UnterminatedSingleQuoteError,
+    UnterminatedDoubleQuoteError, or UnterminatedEscapeError is returned.
+
+

--- a/vendor/github.com/kballard/go-shellquote/doc.go
+++ b/vendor/github.com/kballard/go-shellquote/doc.go
@@ -1,0 +1,3 @@
+// Shellquote provides utilities for joining/splitting strings using sh's
+// word-splitting rules.
+package shellquote

--- a/vendor/github.com/kballard/go-shellquote/quote.go
+++ b/vendor/github.com/kballard/go-shellquote/quote.go
@@ -1,0 +1,102 @@
+package shellquote
+
+import (
+	"bytes"
+	"strings"
+	"unicode/utf8"
+)
+
+// Join quotes each argument and joins them with a space.
+// If passed to /bin/sh, the resulting string will be split back into the
+// original arguments.
+func Join(args ...string) string {
+	var buf bytes.Buffer
+	for i, arg := range args {
+		if i != 0 {
+			buf.WriteByte(' ')
+		}
+		quote(arg, &buf)
+	}
+	return buf.String()
+}
+
+const (
+	specialChars      = "\\'\"`${[|&;<>()*?!"
+	extraSpecialChars = " \t\n"
+	prefixChars       = "~"
+)
+
+func quote(word string, buf *bytes.Buffer) {
+	// We want to try to produce a "nice" output. As such, we will
+	// backslash-escape most characters, but if we encounter a space, or if we
+	// encounter an extra-special char (which doesn't work with
+	// backslash-escaping) we switch over to quoting the whole word. We do this
+	// with a space because it's typically easier for people to read multi-word
+	// arguments when quoted with a space rather than with ugly backslashes
+	// everywhere.
+	origLen := buf.Len()
+
+	if len(word) == 0 {
+		// oops, no content
+		buf.WriteString("''")
+		return
+	}
+
+	cur, prev := word, word
+	atStart := true
+	for len(cur) > 0 {
+		c, l := utf8.DecodeRuneInString(cur)
+		cur = cur[l:]
+		if strings.ContainsRune(specialChars, c) || (atStart && strings.ContainsRune(prefixChars, c)) {
+			// copy the non-special chars up to this point
+			if len(cur) < len(prev) {
+				buf.WriteString(prev[0 : len(prev)-len(cur)-l])
+			}
+			buf.WriteByte('\\')
+			buf.WriteRune(c)
+			prev = cur
+		} else if strings.ContainsRune(extraSpecialChars, c) {
+			// start over in quote mode
+			buf.Truncate(origLen)
+			goto quote
+		}
+		atStart = false
+	}
+	if len(prev) > 0 {
+		buf.WriteString(prev)
+	}
+	return
+
+quote:
+	// quote mode
+	// Use single-quotes, but if we find a single-quote in the word, we need
+	// to terminate the string, emit an escaped quote, and start the string up
+	// again
+	inQuote := false
+	for len(word) > 0 {
+		i := strings.IndexRune(word, '\'')
+		if i == -1 {
+			break
+		}
+		if i > 0 {
+			if !inQuote {
+				buf.WriteByte('\'')
+				inQuote = true
+			}
+			buf.WriteString(word[0:i])
+		}
+		word = word[i+1:]
+		if inQuote {
+			buf.WriteByte('\'')
+			inQuote = false
+		}
+		buf.WriteString("\\'")
+	}
+	if len(word) > 0 {
+		if !inQuote {
+			buf.WriteByte('\'')
+		}
+		buf.WriteString(word)
+		buf.WriteByte('\'')
+	}
+}

--- a/vendor/github.com/kballard/go-shellquote/unquote.go
+++ b/vendor/github.com/kballard/go-shellquote/unquote.go
@@ -1,0 +1,156 @@
+package shellquote
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"unicode/utf8"
+)
+
+var (
+	UnterminatedSingleQuoteError = errors.New("Unterminated single-quoted string")
+	UnterminatedDoubleQuoteError = errors.New("Unterminated double-quoted string")
+	UnterminatedEscapeError      = errors.New("Unterminated backslash-escape")
+)
+
+var (
+	splitChars        = " \n\t"
+	singleChar        = '\''
+	doubleChar        = '"'
+	escapeChar        = '\\'
+	doubleEscapeChars = "$`\"\n\\"
+)
+
+// Split splits a string according to /bin/sh's word-splitting rules. It
+// supports backslash-escapes, single-quotes, and double-quotes. Notably it does
+// not support the $'' style of quoting. It also doesn't attempt to perform any
+// other sort of expansion, including brace expansion, shell expansion, or
+// pathname expansion.
+//
+// If the given input has an unterminated quoted string or ends in a
+// backslash-escape, one of UnterminatedSingleQuoteError,
+// UnterminatedDoubleQuoteError, or UnterminatedEscapeError is returned.
+func Split(input string) (words []string, err error) {
+	var buf bytes.Buffer
+	words = make([]string, 0)
+
+	for len(input) > 0 {
+		// skip any splitChars at the start
+		c, l := utf8.DecodeRuneInString(input)
+		if strings.ContainsRune(splitChars, c) {
+			input = input[l:]
+			continue
+		} else if c == escapeChar {
+			// Look ahead for escaped newline so we can skip over it
+			next := input[l:]
+			if len(next) == 0 {
+				err = UnterminatedEscapeError
+				return
+			}
+			c2, l2 := utf8.DecodeRuneInString(next)
+			if c2 == '\n' {
+				input = next[l2:]
+				continue
+			}
+		}
+
+		var word string
+		word, input, err = splitWord(input, &buf)
+		if err != nil {
+			return
+		}
+		words = append(words, word)
+	}
+	return
+}
+
+func splitWord(input string, buf *bytes.Buffer) (word string, remainder string, err error) {
+	buf.Reset()
+
+raw:
+	{
+		cur := input
+		for len(cur) > 0 {
+			c, l := utf8.DecodeRuneInString(cur)
+			cur = cur[l:]
+			if c == singleChar {
+				buf.WriteString(input[0 : len(input)-len(cur)-l])
+				input = cur
+				goto single
+			} else if c == doubleChar {
+				buf.WriteString(input[0 : len(input)-len(cur)-l])
+				input = cur
+				goto double
+			} else if c == escapeChar {
+				buf.WriteString(input[0 : len(input)-len(cur)-l])
+				input = cur
+				goto escape
+			} else if strings.ContainsRune(splitChars, c) {
+				buf.WriteString(input[0 : len(input)-len(cur)-l])
+				return buf.String(), cur, nil
+			}
+		}
+		if len(input) > 0 {
+			buf.WriteString(input)
+			input = ""
+		}
+		goto done
+	}
+
+escape:
+	{
+		if len(input) == 0 {
+			return "", "", UnterminatedEscapeError
+		}
+		c, l := utf8.DecodeRuneInString(input)
+		if c == '\n' {
+			// a backslash-escaped newline is elided from the output entirely
+		} else {
+			buf.WriteString(input[:l])
+		}
+		input = input[l:]
+	}
+	goto raw
+
+single:
+	{
+		i := strings.IndexRune(input, singleChar)
+		if i == -1 {
+			return "", "", UnterminatedSingleQuoteError
+		}
+		buf.WriteString(input[0:i])
+		input = input[i+1:]
+		goto raw
+	}
+
+double:
+	{
+		cur := input
+		for len(cur) > 0 {
+			c, l := utf8.DecodeRuneInString(cur)
+			cur = cur[l:]
+			if c == doubleChar {
+				buf.WriteString(input[0 : len(input)-len(cur)-l])
+				input = cur
+				goto raw
+			} else if c == escapeChar {
+				// bash only supports certain escapes in double-quoted strings
+				c2, l2 := utf8.DecodeRuneInString(cur)
+				cur = cur[l2:]
+				if strings.ContainsRune(doubleEscapeChars, c2) {
+					buf.WriteString(input[0 : len(input)-len(cur)-l-l2])
+					if c2 == '\n' {
+						// newline is special, skip the backslash entirely
+					} else {
+						buf.WriteRune(c2)
+					}
+					input = cur
+				}
+			}
+		}
+		return "", "", UnterminatedDoubleQuoteError
+	}
+
+done:
+	return buf.String(), input, nil
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -29,6 +29,9 @@ github.com/jstemmer/go-junit-report/v2/junit
 github.com/jstemmer/go-junit-report/v2/parser/gotest
 github.com/jstemmer/go-junit-report/v2/parser/gotest/internal/collector
 github.com/jstemmer/go-junit-report/v2/parser/gotest/internal/reader
+# github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
+## explicit
+github.com/kballard/go-shellquote
 # github.com/pmezard/go-difflib v1.0.0
 ## explicit
 github.com/pmezard/go-difflib/difflib

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -20,6 +20,15 @@ github.com/bitrise-io/go-utils/v2/pathutil
 # github.com/davecgh/go-spew v1.1.1
 ## explicit
 github.com/davecgh/go-spew/spew
+# github.com/google/go-cmp v0.6.0
+## explicit; go 1.13
+# github.com/jstemmer/go-junit-report/v2 v2.1.0
+## explicit; go 1.13
+github.com/jstemmer/go-junit-report/v2/gtr
+github.com/jstemmer/go-junit-report/v2/junit
+github.com/jstemmer/go-junit-report/v2/parser/gotest
+github.com/jstemmer/go-junit-report/v2/parser/gotest/internal/collector
+github.com/jstemmer/go-junit-report/v2/parser/gotest/internal/reader
 # github.com/pmezard/go-difflib v1.0.0
 ## explicit
 github.com/pmezard/go-difflib/difflib


### PR DESCRIPTION
### Checklist

- [x] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [x] `step.yml` and `README.md` is updated with the changes (if needed)

### Version

Requires a *MAJOR* [version update](https://semver.org/)

### Context

This PR modernises the Step by simplifying the package input, exposing coverage mode as a configurable option, capturing test output as a log file, and integrating with Bitrise Test Reporting via JUnit XML export.

### Changes

**Step interface (`step.yml`):**
- `packages` input (newline-separated list) replaced by `package` (single argument passed directly to `go test`, supports `./...`, `.`, or a specific package path) — **breaking change**
- New `covermode` input to configure coverage analysis mode (`none`, `set`, `count`, `atomic`); defaults to `none`
- New `test_options` input for passing additional flags to the `go test` command
- New `test_report_name` input to name the exported JUnit XML test report; falls back to the package name if not set
- New `GO_TEST_RUN_LOG_PATH` output exposing the path to the raw test run log file
- `GO_CODE_COVERAGE_REPORT_PATH` output is now only set when `covermode` is not `none`

**Test Reporting:**
- Test stdout/stderr is captured to a log file alongside being printed to the console
- The log is parsed and converted to JUnit XML using `go-junit-report/v2`
- The report is exported to `BITRISE_TEST_RESULT_DIR` for Bitrise Test Reporting integration

**Implementation:**
- `FileManager` extracted into its own `filemanager` package
- New `testaddon` package encapsulates test result export logic
- `go test` is now run as a single command (no per-package loop); coverage is written directly to a profile file

### Decisions

- **`packages` → `package`**: The old input looped over newline-separated packages running `go test` once per package. The new input passes the argument directly to `go test`, which natively supports patterns like `./...`. This simplifies the implementation and aligns with standard `go test` usage.
- **`covermode: none` disables coverage**: Passing `-coverprofile` when coverage is disabled would create an empty file and export a meaningless output. Coverage-related flags and outputs are skipped entirely when `covermode` is `none`.
- **`-race` flag removed**: Race detection is no longer enabled by default; users who need it can pass `-race` via `test_options`.